### PR TITLE
Add `ReconfigurableOpenTelemetry` to the otel api plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <gitHubRepo>jenkinsci/opentelemetry-api-plugin</gitHubRepo>
         <opentelemetry.version>1.39.0</opentelemetry.version>
         <opentelemetry-instrumentation.version>2.5.0</opentelemetry-instrumentation.version>
-        <opentelemetry-semconv>1.25.0-alpha</opentelemetry-semconv>
+        <opentelemetry-semconv.version>1.25.0-alpha</opentelemetry-semconv.version>
 
         <jenkins.version>2.440.3</jenkins.version>
 
@@ -50,16 +50,75 @@
         <dependency>
             <groupId>io.opentelemetry.semconv</groupId>
             <artifactId>opentelemetry-semconv</artifactId>
-            <version>${opentelemetry-semconv}</version>
+            <version>${opentelemetry-semconv.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.semconv</groupId>
             <artifactId>opentelemetry-semconv-incubating</artifactId>
-            <version>${opentelemetry-semconv}</version>
+            <version>${opentelemetry-semconv.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-instrumentation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-instrumentation-api-incubator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- we get okhttp from io.jenkins.plugins:okhttp-api -->
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- we get okhttp from io.jenkins.plugins:okhttp-api -->
+                    <groupId>com.squareup.okio</groupId>
+                    <artifactId>okio</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>okhttp-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-runtime-telemetry-java8</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
         </dependency>
     </dependencies>
 
@@ -102,6 +161,19 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jenkins-ci.tools</groupId>
+                <artifactId>maven-hpi-plugin</artifactId>
+                <configuration>
+                    <loggers>
+                    </loggers>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
         <connection>scm:git:https://github.com/${gitHubRepo}</connection>

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/ExtendedOpenTelemetry.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/ExtendedOpenTelemetry.java
@@ -1,0 +1,22 @@
+package io.jenkins.plugins.opentelemetry.api;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.ExtensionPoint;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.incubator.events.EventLoggerBuilder;
+import io.opentelemetry.api.incubator.events.EventLoggerProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.resources.Resource;
+
+import java.util.Map;
+
+public interface ExtendedOpenTelemetry extends ExtensionPoint, OpenTelemetry {
+    EventLoggerProvider getEventLoggerProvider();
+    EventLoggerBuilder eventLoggerBuilder(String instrumentationScopeName);
+    ConfigProperties getConfig();
+    Resource getResource();
+    void configure(@NonNull Map<String, String> openTelemetryProperties, Resource openTelemetryResource);
+
+    @Deprecated
+    OpenTelemetry getImplementation();
+}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/InstrumentationScope.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/InstrumentationScope.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.api;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/**
+ * <a href="https://opentelemetry.io/docs/concepts/instrumentation-scope/">OpenTelemetry instrumentation scope</a>,
+ * data structured used by the {@link ReconfigurableOpenTelemetry} implementation
+ */
+class InstrumentationScope {
+    @Nonnull
+    final String instrumentationScopeName;
+    @Nullable
+    final String schemaUrl;
+    @Nullable
+    final String instrumentationScopeVersion;
+
+    public InstrumentationScope(String instrumentationScopeName, @Nullable String schemaUrl, @Nullable String instrumentationScopeVersion) {
+        this.instrumentationScopeName = Objects.requireNonNull(instrumentationScopeName);
+        this.schemaUrl = schemaUrl;
+        this.instrumentationScopeVersion = instrumentationScopeVersion;
+    }
+
+    public InstrumentationScope(@Nonnull String instrumentationScopeName) {
+        this.instrumentationScopeName = instrumentationScopeName;
+        this.schemaUrl = null;
+        this.instrumentationScopeVersion = null;
+    }
+
+    @Override
+    public String toString() {
+        return "InstrumentationScope{" +
+            "instrumentationScopeName='" + instrumentationScopeName + '\'' +
+            ", schemaUrl='" + schemaUrl + '\'' +
+            ", instrumentationScopeVersion='" + instrumentationScopeVersion + '\'' +
+            '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        InstrumentationScope that = (InstrumentationScope) o;
+        return Objects.equals(instrumentationScopeName, that.instrumentationScopeName) && Objects.equals(schemaUrl, that.schemaUrl) && Objects.equals(instrumentationScopeVersion, that.instrumentationScopeVersion);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(instrumentationScopeName, schemaUrl, instrumentationScopeVersion);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/OpenTelemetryLifecycleListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/OpenTelemetryLifecycleListener.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.api;
+
+import hudson.ExtensionPoint;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+
+public interface OpenTelemetryLifecycleListener extends ExtensionPoint, Comparable<OpenTelemetryLifecycleListener> {
+
+    default void afterConfiguration(ConfigProperties configProperties){}
+
+    /**
+     * @return the ordinal of this otel component to execute step handlers in predictable order. The smallest ordinal is handled first.
+     */
+    default int ordinal() {
+        return 0;
+    }
+
+    @Override
+    default int compareTo(OpenTelemetryLifecycleListener other) {
+        if (this.ordinal() == other.ordinal()) {
+            return this.getClass().getName().compareTo(other.getClass().getName());
+        } else {
+            return Integer.compare(this.ordinal(), other.ordinal());
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableEventLoggerProvider.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableEventLoggerProvider.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.api;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.opentelemetry.api.incubator.events.EventBuilder;
+import io.opentelemetry.api.incubator.events.EventLogger;
+import io.opentelemetry.api.incubator.events.EventLoggerBuilder;
+import io.opentelemetry.api.incubator.events.EventLoggerProvider;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * <p>
+ * A {@link EventLoggerProvider} that allows to reconfigure the {@link EventLogger}s.
+ * </p>
+ * <p>
+ * We need reconfigurability because Jenkins supports changing the configuration of the OpenTelemetry params at runtime.
+ * All instantiated eventLoggers are reconfigured when the configuration changes, when
+ * {@link ReconfigurableEventLoggerProvider#setDelegate(EventLoggerProvider)} is invoked.
+ * </p>
+ */
+class ReconfigurableEventLoggerProvider implements EventLoggerProvider {
+
+    private final ConcurrentMap<InstrumentationScope, ReconfigurableEventLogger> eventLoggers = new ConcurrentHashMap<>();
+    private EventLoggerProvider delegate = EventLoggerProvider.noop();
+
+    @Override
+    public EventLoggerBuilder eventLoggerBuilder(String instrumentationScopeName) {
+        return new ReconfigurableEventLoggerBuilder(delegate.eventLoggerBuilder(instrumentationScopeName), instrumentationScopeName);
+    }
+
+    @Override
+    public EventLogger get(String instrumentationScopeName) {
+        return eventLoggers.computeIfAbsent(new InstrumentationScope(instrumentationScopeName), key -> new ReconfigurableEventLogger(delegate.get(key.instrumentationScopeName)));
+    }
+
+    public void setDelegate(EventLoggerProvider delegateEventLoggerBuilder) {
+        this.delegate = delegateEventLoggerBuilder;
+        eventLoggers.forEach((key, reconfigurableEventLogger) -> {
+            EventLoggerBuilder eventLoggerBuilder = delegateEventLoggerBuilder.eventLoggerBuilder(key.instrumentationScopeName);
+            Optional.ofNullable(key.schemaUrl).ifPresent(eventLoggerBuilder::setSchemaUrl);
+            Optional.ofNullable(key.instrumentationScopeVersion).ifPresent(eventLoggerBuilder::setInstrumentationVersion);
+            reconfigurableEventLogger.delegateEventLogger = eventLoggerBuilder.build();
+        });
+    }
+
+    @VisibleForTesting
+    protected static class ReconfigurableEventLogger implements EventLogger {
+        EventLogger delegateEventLogger;
+
+        public ReconfigurableEventLogger(EventLogger delegateEventLogger) {
+            this.delegateEventLogger = Objects.requireNonNull(delegateEventLogger);
+        }
+
+        @Override
+        public EventBuilder builder(String eventName) {
+            return delegateEventLogger.builder(eventName);
+        }
+    }
+
+    @VisibleForTesting
+    protected class ReconfigurableEventLoggerBuilder implements EventLoggerBuilder {
+        EventLoggerBuilder delegate;
+        String instrumentationScopeName;
+        String schemaUrl;
+        String instrumentationScopeVersion;
+
+        public ReconfigurableEventLoggerBuilder(EventLoggerBuilder delegate, String instrumentationScopeName) {
+            this.delegate = Objects.requireNonNull(delegate);
+            this.instrumentationScopeName = Objects.requireNonNull(instrumentationScopeName);
+        }
+
+        @Override
+        public EventLoggerBuilder setSchemaUrl(String schemaUrl) {
+            delegate.setSchemaUrl(schemaUrl);
+            this.schemaUrl = schemaUrl;
+            return this;
+        }
+
+        @Override
+        public EventLoggerBuilder setInstrumentationVersion(String instrumentationScopeVersion) {
+            delegate.setInstrumentationVersion(instrumentationScopeVersion);
+            this.instrumentationScopeVersion = instrumentationScopeVersion;
+            return this;
+        }
+
+        @Override
+        public EventLogger build() {
+            InstrumentationScope key = new InstrumentationScope(instrumentationScopeName, schemaUrl, instrumentationScopeVersion);
+            return eventLoggers.computeIfAbsent(key, k -> new ReconfigurableEventLogger(delegate.build()));
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableLoggerProvider.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableLoggerProvider.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.api;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.opentelemetry.api.logs.LogRecordBuilder;
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.api.logs.LoggerBuilder;
+import io.opentelemetry.api.logs.LoggerProvider;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * <p>
+ * A {@link LoggerProvider} that allows to reconfigure the {@link Logger}s.
+ * </p>
+ * <p>
+ * We need reconfigurability because Jenkins supports changing the configuration of the OpenTelemetry params at runtime.
+ * All instantiated loggers are reconfigured when the configuration changes, when
+ * {@link ReconfigurableLoggerProvider#setDelegate(LoggerProvider)} is invoked.
+ * </p>
+ */
+class ReconfigurableLoggerProvider implements LoggerProvider {
+    private LoggerProvider delegate;
+
+    private final ConcurrentMap<InstrumentationScope, ReconfigurableLogger> loggers = new ConcurrentHashMap<>();
+
+    public ReconfigurableLoggerProvider() {
+        this(LoggerProvider.noop());
+    }
+
+    public ReconfigurableLoggerProvider(LoggerProvider delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public LoggerBuilder loggerBuilder(String instrumentationScopeName) {
+        return new ReconfigurableLoggerBuilder(delegate.loggerBuilder(instrumentationScopeName), instrumentationScopeName);
+    }
+
+    @Override
+    public Logger get(String instrumentationScopeName) {
+        InstrumentationScope instrumentationScope = new InstrumentationScope(instrumentationScopeName);
+        return loggers.computeIfAbsent(instrumentationScope, scope -> new ReconfigurableLogger(delegate.get(instrumentationScopeName)));
+    }
+
+    public void setDelegate(LoggerProvider delegate) {
+        this.delegate = delegate;
+        loggers.forEach((instrumentationScope, reconfigurableTracer) -> {
+            LoggerBuilder loggerBuilder = delegate.loggerBuilder(instrumentationScope.instrumentationScopeName);
+            Optional.ofNullable(instrumentationScope.instrumentationScopeVersion).ifPresent(loggerBuilder::setInstrumentationVersion);
+            Optional.ofNullable(instrumentationScope.schemaUrl).ifPresent(loggerBuilder::setSchemaUrl);
+            reconfigurableTracer.setDelegate(loggerBuilder.build());
+        });
+    }
+
+    @VisibleForTesting
+    protected class ReconfigurableLoggerBuilder implements LoggerBuilder {
+        LoggerBuilder delegate;
+        String instrumentationScopeName;
+        String schemaUrl;
+        String instrumentationScopeVersion;
+
+        public ReconfigurableLoggerBuilder(LoggerBuilder delegate, String instrumentationScopeName) {
+            this.delegate = Objects.requireNonNull(delegate);
+            this.instrumentationScopeName = Objects.requireNonNull(instrumentationScopeName);
+        }
+
+        @Override
+        public LoggerBuilder setSchemaUrl(String schemaUrl) {
+            this.schemaUrl = schemaUrl;
+            delegate.setSchemaUrl(schemaUrl);
+            return this;
+        }
+
+        @Override
+        public LoggerBuilder setInstrumentationVersion(String instrumentationScopeVersion) {
+            this.instrumentationScopeVersion = instrumentationScopeVersion;
+            delegate.setInstrumentationVersion(instrumentationScopeVersion);
+            return this;
+        }
+
+        @Override
+        public Logger build() {
+            InstrumentationScope instrumentationScope = new InstrumentationScope(instrumentationScopeName, schemaUrl, instrumentationScopeVersion);
+            return loggers.computeIfAbsent(instrumentationScope, scope -> new ReconfigurableLogger(delegate.build()));
+        }
+    }
+
+    @VisibleForTesting
+    protected static class ReconfigurableLogger implements Logger {
+        Logger delegate;
+
+        public ReconfigurableLogger(Logger delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public synchronized LogRecordBuilder logRecordBuilder() {
+            return delegate.logRecordBuilder();
+        }
+
+        public synchronized void setDelegate(Logger delegate) {
+            this.delegate = delegate;
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableMeterProvider.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableMeterProvider.java
@@ -1,0 +1,2228 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.api;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.incubator.metrics.ExtendedDoubleHistogramBuilder;
+import io.opentelemetry.api.incubator.metrics.ExtendedLongHistogramBuilder;
+import io.opentelemetry.api.metrics.BatchCallback;
+import io.opentelemetry.api.metrics.DoubleCounter;
+import io.opentelemetry.api.metrics.DoubleCounterBuilder;
+import io.opentelemetry.api.metrics.DoubleGauge;
+import io.opentelemetry.api.metrics.DoubleGaugeBuilder;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
+import io.opentelemetry.api.metrics.DoubleUpDownCounter;
+import io.opentelemetry.api.metrics.DoubleUpDownCounterBuilder;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongCounterBuilder;
+import io.opentelemetry.api.metrics.LongGauge;
+import io.opentelemetry.api.metrics.LongGaugeBuilder;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.LongHistogramBuilder;
+import io.opentelemetry.api.metrics.LongUpDownCounter;
+import io.opentelemetry.api.metrics.LongUpDownCounterBuilder;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterBuilder;
+import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.metrics.ObservableDoubleCounter;
+import io.opentelemetry.api.metrics.ObservableDoubleGauge;
+import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
+import io.opentelemetry.api.metrics.ObservableDoubleUpDownCounter;
+import io.opentelemetry.api.metrics.ObservableLongCounter;
+import io.opentelemetry.api.metrics.ObservableLongGauge;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import io.opentelemetry.api.metrics.ObservableLongUpDownCounter;
+import io.opentelemetry.api.metrics.ObservableMeasurement;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfoBuilder;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * <p>
+ * A {@link MeterProvider} that allows to reconfigure the {@link Meter}s.
+ * </p>
+ * <p>
+ * We need reconfigurability because Jenkins supports changing the configuration of the OpenTelemetry params at runtime.
+ * All instantiated meters are reconfigured when the configuration changes, when
+ * {@link ReconfigurableMeterProvider#setDelegate(MeterProvider)} is invoked.
+ * </p>
+ */
+@ThreadSafe
+class ReconfigurableMeterProvider implements MeterProvider {
+    final static Logger logger = Logger.getLogger(ReconfigurableMeterProvider.class.getName());
+
+    @GuardedBy("lock")
+    private MeterProvider delegate;
+
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+    private final ConcurrentMap<InstrumentationScopeInfo, ReconfigurableMeter> meters = new ConcurrentHashMap<>();
+
+    public ReconfigurableMeterProvider() {
+        this(MeterProvider.noop());
+    }
+
+    public ReconfigurableMeterProvider(MeterProvider delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Meter get(String instrumentationScopeName) {
+        lock.readLock().lock();
+        try {
+            return meters.computeIfAbsent(
+                InstrumentationScopeInfo.create(instrumentationScopeName),
+                instrumentationScopeInfo -> new ReconfigurableMeter(delegate.get(instrumentationScopeInfo.getName()), lock));
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public void setDelegate(MeterProvider delegate) {
+        lock.writeLock().lock();
+        try {
+            this.delegate = delegate;
+            meters.forEach((instrumentationScopeInfo, reconfigurableMeter) -> {
+                MeterBuilder meterBuilder = delegate.meterBuilder(instrumentationScopeInfo.getName());
+                Optional.ofNullable(instrumentationScopeInfo.getVersion()).ifPresent(meterBuilder::setInstrumentationVersion);
+                Optional.ofNullable(instrumentationScopeInfo.getSchemaUrl()).ifPresent(meterBuilder::setSchemaUrl);
+                reconfigurableMeter.setDelegate(meterBuilder.build());
+            });
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public MeterBuilder meterBuilder(String instrumentationScopeName) {
+        lock.readLock().lock();
+        try {
+            return new ReconfigurableMeterBuilder(delegate.meterBuilder(instrumentationScopeName), instrumentationScopeName, lock);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public MeterProvider getDelegate() {
+        lock.readLock().lock();
+        try {
+            return delegate;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @VisibleForTesting
+    protected class ReconfigurableMeterBuilder implements MeterBuilder {
+        final ReadWriteLock lock;
+        final MeterBuilder delegate;
+        final InstrumentationScopeInfoBuilder instrumentationScopeInfoBuilder;
+
+
+        public ReconfigurableMeterBuilder(MeterBuilder delegate, String instrumentationScopeName, ReadWriteLock lock) {
+            this.delegate = Objects.requireNonNull(delegate);
+            this.instrumentationScopeInfoBuilder = InstrumentationScopeInfo.builder(instrumentationScopeName);
+            this.lock = lock;
+        }
+
+        @Override
+        public MeterBuilder setSchemaUrl(String schemaUrl) {
+            lock.readLock().lock();
+            try {
+                delegate.setSchemaUrl(schemaUrl);
+                this.instrumentationScopeInfoBuilder.setSchemaUrl(schemaUrl);
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public MeterBuilder setInstrumentationVersion(String instrumentationScopeVersion) {
+            lock.readLock().lock();
+            try {
+                delegate.setInstrumentationVersion(instrumentationScopeVersion);
+                this.instrumentationScopeInfoBuilder.setVersion(instrumentationScopeVersion);
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public Meter build() {
+            lock.readLock().lock();
+            try {
+                InstrumentationScopeInfo instrumentationScopeInfo = this.instrumentationScopeInfoBuilder.build();
+                return meters.computeIfAbsent(instrumentationScopeInfo, k -> new ReconfigurableMeter(delegate.build(), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    static class InstrumentKey {
+        final String name;
+        @Nullable
+        final String description;
+        @Nullable
+        final String unit;
+        @Nullable
+        final List<AttributeKey<?>> attributes;
+
+        public InstrumentKey(String name, @Nullable String description, @Nullable String unit, @Nullable List<AttributeKey<?>> attributes) {
+            this.name = name;
+            this.description = description;
+            this.unit = unit;
+            this.attributes = attributes;
+        }
+
+        public InstrumentKey(String name, @Nullable String description, @Nullable String unit) {
+            this(name, description, unit, null);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            InstrumentKey that = (InstrumentKey) o;
+            return Objects.equals(name, that.name) && Objects.equals(description, that.description) && Objects.equals(unit, that.unit) && Objects.equals(attributes, that.attributes);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, description, unit, attributes);
+        }
+    }
+
+    static class HistogramKey<T extends Number> extends InstrumentKey {
+        @Nullable
+        final List<T> bucketBoundaries;
+
+        public HistogramKey(String name, @Nullable String description, @Nullable String unit, @Nullable List<AttributeKey<?>> attributes, @Nullable List<T> bucketBoundaries) {
+            super(name, description, unit, attributes);
+            this.bucketBoundaries = bucketBoundaries;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            HistogramKey<?> that = (HistogramKey<?>) o;
+            return Objects.equals(bucketBoundaries, that.bucketBoundaries);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), bucketBoundaries);
+        }
+    }
+
+
+    static class ObservableLongMeasurementCallbackKey {
+        final String name;
+        @Nullable
+        final String description;
+        @Nullable
+        final String unit;
+        final Consumer<ObservableLongMeasurement> callback;
+
+        public ObservableLongMeasurementCallbackKey(String name, @Nullable String description, @Nullable String unit, Consumer<ObservableLongMeasurement> callback) {
+            this.name = name;
+            this.description = description;
+            this.unit = unit;
+            this.callback = callback;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ObservableLongMeasurementCallbackKey that = (ObservableLongMeasurementCallbackKey) o;
+            return Objects.equals(name, that.name) && Objects.equals(description, that.description) && Objects.equals(unit, that.unit) && Objects.equals(callback, that.callback);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, description, unit, callback);
+        }
+    }
+
+    static class ObservableDoubleMeasurementCallbackKey {
+        final String name;
+        @Nullable
+        final String description;
+        @Nullable
+        final String unit;
+        final Consumer<ObservableDoubleMeasurement> callback;
+
+        public ObservableDoubleMeasurementCallbackKey(String name, @Nullable String description, @Nullable String unit, Consumer<ObservableDoubleMeasurement> callback) {
+            this.name = name;
+            this.description = description;
+            this.unit = unit;
+            this.callback = callback;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ObservableDoubleMeasurementCallbackKey that = (ObservableDoubleMeasurementCallbackKey) o;
+            return Objects.equals(name, that.name) && Objects.equals(description, that.description) && Objects.equals(unit, that.unit) && Objects.equals(callback, that.callback);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, description, unit, callback);
+        }
+    }
+
+    @ThreadSafe
+    @VisibleForTesting
+    protected static class ReconfigurableMeter implements Meter {
+        final ReadWriteLock lock;
+        @GuardedBy("lock")
+        Meter delegate;
+
+        // COUNTERS
+        // long counters
+        final ConcurrentMap<InstrumentKey, ReconfigurableLongCounter> longCounters = new ConcurrentHashMap<>();
+        final ConcurrentMap<ObservableLongMeasurementCallbackKey, ReconfigurableObservableLongCounter> observableLongCounters = new ConcurrentHashMap<>();
+        final ConcurrentMap<InstrumentKey, ReconfigurableObservableLongMeasurement> observableLongCounterMeasurements = new ConcurrentHashMap<>();
+        // double counters
+        final ConcurrentMap<InstrumentKey, ReconfigurableDoubleCounter> doubleCounters = new ConcurrentHashMap<>();
+        final ConcurrentMap<ObservableDoubleMeasurementCallbackKey, ReconfigurableObservableDoubleCounter> observableDoubleCounters = new ConcurrentHashMap<>();
+        final ConcurrentMap<InstrumentKey, ReconfigurableObservableDoubleMeasurement> observableDoubleCounterMeasurements = new ConcurrentHashMap<>();
+
+        // GAUGES
+        // Long gauges
+        final ConcurrentMap<InstrumentKey, ReconfigurableLongGauge> longGauges = new ConcurrentHashMap<>();
+        final ConcurrentMap<ObservableLongMeasurementCallbackKey, ReconfigurableObservableLongGauge> observableLongGauges = new ConcurrentHashMap<>();
+        final ConcurrentMap<InstrumentKey, ReconfigurableObservableLongMeasurement> observableLongGaugeMeasurements = new ConcurrentHashMap<>();
+        // double gauges
+        final ConcurrentMap<InstrumentKey, ReconfigurableDoubleGauge> doubleGauges = new ConcurrentHashMap<>();
+        final ConcurrentMap<ObservableDoubleMeasurementCallbackKey, ReconfigurableObservableDoubleGauge> observableDoubleGauges = new ConcurrentHashMap<>();
+        final ConcurrentMap<InstrumentKey, ReconfigurableObservableDoubleMeasurement> observableDoubleGaugeMeasurements = new ConcurrentHashMap<>();
+
+        // UP DOWN COUNTERS
+        // Long counters
+        final ConcurrentMap<InstrumentKey, ReconfigurableLongUpDownCounter> longUpDownCounters = new ConcurrentHashMap<>();
+        final ConcurrentMap<ObservableLongMeasurementCallbackKey, ReconfigurableObservableLongUpDownCounter> observableLongUpDownCounters = new ConcurrentHashMap<>();
+        final ConcurrentMap<InstrumentKey, ReconfigurableObservableLongMeasurement> observableLongUpDownCounterMeasurements = new ConcurrentHashMap<>();
+        // double counters
+        final ConcurrentMap<InstrumentKey, ReconfigurableDoubleUpDownCounter> doubleUpDownCounters = new ConcurrentHashMap<>();
+        final ConcurrentMap<ObservableDoubleMeasurementCallbackKey, ReconfigurableObservableDoubleUpDownCounter> observableDoubleUpDownCounters = new ConcurrentHashMap<>();
+        final ConcurrentMap<InstrumentKey, ReconfigurableObservableDoubleMeasurement> observableDoubleUpDownCounterMeasurements = new ConcurrentHashMap<>();
+
+        // HISTOGRAMS
+        // Long histograms
+        final ConcurrentMap<HistogramKey<Long>, ReconfigurableLongHistogram> longHistograms = new ConcurrentHashMap<>();
+        // Double histograms
+        final ConcurrentMap<HistogramKey<Double>, ReconfigurableDoubleHistogram> doubleHistograms = new ConcurrentHashMap<>();
+
+        // BATCH CALLBACKS
+        final ConcurrentMap<BatchCallbackKey, ReconfigurableBatchCallback> batchCallbacks = new ConcurrentHashMap<>();
+
+        public ReconfigurableMeter(Meter delegate, ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.lock = lock;
+        }
+
+        @Override
+        public BatchCallback batchCallback(Runnable callback, ObservableMeasurement observableMeasurement, ObservableMeasurement... additionalMeasurements) {
+            lock.readLock().lock();
+            // io.opentelemetry.sdk.metrics.SdkMeter.batchCallback require the original ObservableMeasurement
+            // see https://github.com/open-telemetry/opentelemetry-java/blob/v1.39.0/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java#L130
+            try {
+                BatchCallbackKey key = new BatchCallbackKey(callback, observableMeasurement, additionalMeasurements);
+                ObservableMeasurement originalObservableMeasurement = ((ReconfigurableObservableMeasurement<?>) observableMeasurement).getDelegate();
+                ObservableMeasurement[] originalAdditionalMeasurements = Arrays.stream(additionalMeasurements).map(additionalMeasurement -> ((ReconfigurableObservableMeasurement<? extends ObservableMeasurement>) additionalMeasurement).getDelegate()).toArray(ObservableMeasurement[]::new);
+                return this.batchCallbacks.computeIfAbsent(key, k -> new ReconfigurableBatchCallback(delegate.batchCallback(callback, originalObservableMeasurement, originalAdditionalMeasurements), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public DoubleGaugeBuilder gaugeBuilder(String name) {
+            lock.readLock().lock();
+            try {
+                return new ReconfigurableDoubleGaugeBuilder(delegate.gaugeBuilder(name), name,
+                    doubleGauges, observableDoubleGauges, observableDoubleGaugeMeasurements,
+                    longGauges, observableLongGauges, observableLongGaugeMeasurements,
+                    lock);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public DoubleHistogramBuilder histogramBuilder(String name) {
+            lock.readLock().lock();
+            try {
+                DoubleHistogramBuilder doubleHistogramBuilder = delegate.histogramBuilder(name);
+                if (doubleHistogramBuilder instanceof ExtendedDoubleHistogramBuilder) {
+                    ExtendedDoubleHistogramBuilder histogramBuilder = (ExtendedDoubleHistogramBuilder) doubleHistogramBuilder;
+                    return new ReconfigurableDoubleHistogramBuilder(histogramBuilder, name, doubleHistograms, longHistograms, lock);
+                } else {
+                    return new ReconfigurableDoubleHistogramBuilder(doubleHistogramBuilder, name, doubleHistograms, longHistograms, lock);
+                }
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public LongUpDownCounterBuilder upDownCounterBuilder(String name) {
+            lock.readLock().lock();
+            try {
+                return new ReconfigurableLongUpDownCounterBuilder(delegate.upDownCounterBuilder(name), name,
+                    longUpDownCounters, doubleUpDownCounters,
+                    observableLongUpDownCounters, observableLongUpDownCounterMeasurements, observableDoubleUpDownCounters, observableDoubleUpDownCounterMeasurements, lock);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public LongCounterBuilder counterBuilder(String name) {
+            lock.readLock().lock();
+            try {
+                return new ReconfigurableLongCounterBuilder(delegate.counterBuilder(name), name, longCounters, doubleCounters, observableLongCounters, observableLongCounterMeasurements, observableDoubleCounters, observableDoubleCounterMeasurements, lock);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        public void setDelegate(Meter delegate) {
+            lock.writeLock().lock();
+            try {
+                this.delegate = delegate;
+                // COUNTERS
+                // Long counters
+                this.longCounters.forEach((counterKey, reconfigurableLongCounter) -> {
+                    LongCounterBuilder longCounterBuilder = delegate.counterBuilder(counterKey.name);
+                    Optional.ofNullable(counterKey.description).ifPresent(longCounterBuilder::setDescription);
+                    Optional.ofNullable(counterKey.unit).ifPresent(longCounterBuilder::setUnit);
+                    logger.log(Level.FINE, () -> "Reconfiguring long counter " + counterKey.name);
+                    reconfigurableLongCounter.setDelegate(longCounterBuilder.build());
+                });
+                this.observableLongCounters.forEach((callbackKey, reconfigurableObservableLongCounter) -> {
+                    LongCounterBuilder longCounterBuilder = delegate.counterBuilder(callbackKey.name);
+                    Optional.ofNullable(callbackKey.description).ifPresent(longCounterBuilder::setDescription);
+                    Optional.ofNullable(callbackKey.unit).ifPresent(longCounterBuilder::setUnit);
+                    logger.log(Level.FINE, () -> "Reconfiguring observable long counter " + callbackKey.name);
+                    reconfigurableObservableLongCounter.setDelegate(longCounterBuilder.buildWithCallback(callbackKey.callback));
+                });
+                this.observableLongCounterMeasurements.forEach((counterKey, reconfigurableObservableLongMeasurement) -> {
+                    LongCounterBuilder longCounterBuilder = delegate.counterBuilder(counterKey.name);
+                    Optional.ofNullable(counterKey.description).ifPresent(longCounterBuilder::setDescription);
+                    Optional.ofNullable(counterKey.unit).ifPresent(longCounterBuilder::setUnit);
+                    logger.log(Level.FINE, () -> "Reconfiguring observable long measurement " + counterKey.name);
+                    reconfigurableObservableLongMeasurement.setDelegate(longCounterBuilder.buildObserver());
+                });
+
+                // Double counters
+                this.doubleCounters.forEach((counterKey, reconfigurableDoubleCounter) -> {
+                    DoubleCounterBuilder doubleCounterBuilder = delegate.counterBuilder(counterKey.name).ofDoubles();
+                    Optional.ofNullable(counterKey.description).ifPresent(doubleCounterBuilder::setDescription);
+                    Optional.ofNullable(counterKey.unit).ifPresent(doubleCounterBuilder::setUnit);
+                    logger.log(Level.FINE, () -> "Reconfiguring double counter " + counterKey.name);
+                    reconfigurableDoubleCounter.setDelegate(doubleCounterBuilder.build());
+                });
+                this.observableDoubleCounters.forEach((callbackKey, reconfigurableObservableDoubleCounter) -> {
+                    DoubleCounterBuilder doubleCounterBuilder = delegate.counterBuilder(callbackKey.name).ofDoubles();
+                    Optional.ofNullable(callbackKey.description).ifPresent(doubleCounterBuilder::setDescription);
+                    Optional.ofNullable(callbackKey.unit).ifPresent(doubleCounterBuilder::setUnit);
+                    logger.log(Level.FINE, () -> "Reconfiguring observable double counter " + callbackKey.name);
+                    reconfigurableObservableDoubleCounter.setDelegate(doubleCounterBuilder.buildWithCallback(callbackKey.callback));
+                });
+                this.observableDoubleCounterMeasurements.forEach((counterKey, reconfigurableObservableDoubleMeasurement) -> {
+                    DoubleCounterBuilder doubleCounterBuilder = delegate.counterBuilder(counterKey.name).ofDoubles();
+                    Optional.ofNullable(counterKey.description).ifPresent(doubleCounterBuilder::setDescription);
+                    Optional.ofNullable(counterKey.unit).ifPresent(doubleCounterBuilder::setUnit);
+                    logger.log(Level.FINE, () -> "Reconfiguring observable double measurement " + counterKey.name);
+                    reconfigurableObservableDoubleMeasurement.setDelegate(doubleCounterBuilder.buildObserver());
+                });
+
+                // GAUGES
+                // Double gauges
+                this.doubleGauges.forEach((counterKey, reconfigurableDoubleGauge) -> {
+                    DoubleGaugeBuilder doubleGaugeBuilder = delegate.gaugeBuilder(counterKey.name);
+                    Optional.ofNullable(counterKey.description).ifPresent(doubleGaugeBuilder::setDescription);
+                    Optional.ofNullable(counterKey.unit).ifPresent(doubleGaugeBuilder::setUnit);
+                    logger.log(Level.FINE, () -> "Reconfiguring double gauge " + counterKey.name);
+                    reconfigurableDoubleGauge.setDelegate(doubleGaugeBuilder.build());
+                });
+                this.observableDoubleGauges.forEach((callbackKey, reconfigurableObservableDoubleGauge) -> {
+                    DoubleGaugeBuilder doubleGaugeBuilder = delegate.gaugeBuilder(callbackKey.name);
+                    Optional.ofNullable(callbackKey.description).ifPresent(doubleGaugeBuilder::setDescription);
+                    Optional.ofNullable(callbackKey.unit).ifPresent(doubleGaugeBuilder::setUnit);
+                    logger.log(Level.FINE, () -> "Reconfiguring observable double gauge " + callbackKey.name);
+                    reconfigurableObservableDoubleGauge.setDelegate(doubleGaugeBuilder.buildWithCallback(callbackKey.callback));
+                });
+                this.observableDoubleGaugeMeasurements.forEach((counterKey, reconfigurableObservableDoubleMeasurement) -> {
+                    DoubleGaugeBuilder doubleGaugeBuilder = delegate.gaugeBuilder(counterKey.name);
+                    Optional.ofNullable(counterKey.description).ifPresent(doubleGaugeBuilder::setDescription);
+                    Optional.ofNullable(counterKey.unit).ifPresent(doubleGaugeBuilder::setUnit);
+                    logger.log(Level.FINE, () -> "Reconfiguring observable double measurement " + counterKey.name);
+                    reconfigurableObservableDoubleMeasurement.setDelegate(doubleGaugeBuilder.buildObserver());
+                });
+
+                // Long gauges
+                this.longGauges.forEach((counterKey, reconfigurableLongGauge) -> {
+                    LongGaugeBuilder longGaugeBuilder = delegate.gaugeBuilder(counterKey.name).ofLongs();
+                    Optional.ofNullable(counterKey.description).ifPresent(longGaugeBuilder::setDescription);
+                    Optional.ofNullable(counterKey.unit).ifPresent(longGaugeBuilder::setUnit);
+                    logger.log(Level.FINE, () -> "Reconfiguring long gauge " + counterKey.name);
+                    reconfigurableLongGauge.setDelegate(longGaugeBuilder.build());
+                });
+                this.observableLongGauges.forEach((callbackKey, reconfigurableObservableLongGauge) -> {
+                    LongGaugeBuilder longGaugeBuilder = delegate.gaugeBuilder(callbackKey.name).ofLongs();
+                    Optional.ofNullable(callbackKey.description).ifPresent(longGaugeBuilder::setDescription);
+                    Optional.ofNullable(callbackKey.unit).ifPresent(longGaugeBuilder::setUnit);
+                    logger.log(Level.FINE, () -> "Reconfiguring observable long gauge " + callbackKey.name);
+                    reconfigurableObservableLongGauge.setDelegate(longGaugeBuilder.buildWithCallback(callbackKey.callback));
+                });
+                this.observableLongGaugeMeasurements.forEach((counterKey, reconfigurableObservableLongMeasurement) -> {
+                    LongGaugeBuilder longGaugeBuilder = delegate.gaugeBuilder(counterKey.name).ofLongs();
+                    Optional.ofNullable(counterKey.description).ifPresent(longGaugeBuilder::setDescription);
+                    Optional.ofNullable(counterKey.unit).ifPresent(longGaugeBuilder::setUnit);
+                    logger.log(Level.FINE, () -> "Reconfiguring observable long measurement " + counterKey.name);
+                    reconfigurableObservableLongMeasurement.setDelegate(longGaugeBuilder.buildObserver());
+                });
+
+                // UPDOWN COUNTERS
+                // Long updown counters
+                this.longUpDownCounters.forEach((counterKey, reconfigurableLongUpDownCounter) -> {
+                    LongUpDownCounterBuilder longUpDownCounterBuilder = delegate.upDownCounterBuilder(counterKey.name);
+                    Optional.ofNullable(counterKey.description).ifPresent(longUpDownCounterBuilder::setDescription);
+                    Optional.ofNullable(counterKey.unit).ifPresent(longUpDownCounterBuilder::setUnit);
+                    logger.log(Level.FINE, () -> "Reconfiguring long updown counter " + counterKey.name);
+                    reconfigurableLongUpDownCounter.setDelegate(longUpDownCounterBuilder.build());
+                });
+                this.observableLongUpDownCounters.forEach((callbackKey, reconfigurableObservableLongUpDownCounter) -> {
+                    LongUpDownCounterBuilder longUpDownCounterBuilder = delegate.upDownCounterBuilder(callbackKey.name);
+                    Optional.ofNullable(callbackKey.description).ifPresent(longUpDownCounterBuilder::setDescription);
+                    Optional.ofNullable(callbackKey.unit).ifPresent(longUpDownCounterBuilder::setUnit);
+                    logger.log(Level.FINE, () -> "Reconfiguring observable long updown counter " + callbackKey.name);
+                    reconfigurableObservableLongUpDownCounter.setDelegate(longUpDownCounterBuilder.buildWithCallback(callbackKey.callback));
+                });
+                this.observableLongUpDownCounterMeasurements.forEach((counterKey, reconfigurableObservableLongMeasurement) -> {
+                    LongUpDownCounterBuilder longUpDownCounterBuilder = delegate.upDownCounterBuilder(counterKey.name);
+                    Optional.ofNullable(counterKey.description).ifPresent(longUpDownCounterBuilder::setDescription);
+                    Optional.ofNullable(counterKey.unit).ifPresent(longUpDownCounterBuilder::setUnit);
+                    logger.log(Level.FINE, () -> "Reconfiguring observable long updown measurement " + counterKey.name);
+                    reconfigurableObservableLongMeasurement.setDelegate(longUpDownCounterBuilder.buildObserver());
+                });
+
+                // Double updown counters
+                this.doubleUpDownCounters.forEach((counterKey, reconfigurableDoubleUpDownCounter) -> {
+                    DoubleUpDownCounterBuilder doubleUpDownCounterBuilder = delegate.upDownCounterBuilder(counterKey.name).ofDoubles();
+                    Optional.ofNullable(counterKey.description).ifPresent(doubleUpDownCounterBuilder::setDescription);
+                    Optional.ofNullable(counterKey.unit).ifPresent(doubleUpDownCounterBuilder::setUnit);
+                    logger.log(Level.FINE, () -> "Reconfiguring double updown counter " + counterKey.name);
+                    reconfigurableDoubleUpDownCounter.setDelegate(doubleUpDownCounterBuilder.build());
+                });
+                this.observableDoubleUpDownCounters.forEach((callbackKey, reconfigurableObservableDoubleUpDownCounter) -> {
+                    DoubleUpDownCounterBuilder doubleUpDownCounterBuilder = delegate.upDownCounterBuilder(callbackKey.name).ofDoubles();
+                    Optional.ofNullable(callbackKey.description).ifPresent(doubleUpDownCounterBuilder::setDescription);
+                    Optional.ofNullable(callbackKey.unit).ifPresent(doubleUpDownCounterBuilder::setUnit);
+                    logger.log(Level.FINE, () -> "Reconfiguring observable double updown counter " + callbackKey.name);
+                    reconfigurableObservableDoubleUpDownCounter.setDelegate(doubleUpDownCounterBuilder.buildWithCallback(callbackKey.callback));
+                });
+                this.observableDoubleUpDownCounterMeasurements.forEach((counterKey, reconfigurableObservableDoubleMeasurement) -> {
+                    DoubleUpDownCounterBuilder doubleUpDownCounterBuilder = delegate.upDownCounterBuilder(counterKey.name).ofDoubles();
+                    Optional.ofNullable(counterKey.description).ifPresent(doubleUpDownCounterBuilder::setDescription);
+                    Optional.ofNullable(counterKey.unit).ifPresent(doubleUpDownCounterBuilder::setUnit);
+                    logger.log(Level.FINE, () -> "Reconfiguring observable double updown measurement " + counterKey.name);
+                    reconfigurableObservableDoubleMeasurement.setDelegate(doubleUpDownCounterBuilder.buildObserver());
+                });
+
+                // HISTOGRAMS
+                // Long histograms
+                this.longHistograms.forEach((histogramKey, reconfigurableLongHistogram) -> {
+                    LongHistogramBuilder longHistogramBuilder = delegate.histogramBuilder(histogramKey.name).ofLongs();
+                    Optional.ofNullable(histogramKey.description).ifPresent(longHistogramBuilder::setDescription);
+                    Optional.ofNullable(histogramKey.unit).ifPresent(longHistogramBuilder::setUnit);
+                    Optional.ofNullable(histogramKey.bucketBoundaries).ifPresent(longHistogramBuilder::setExplicitBucketBoundariesAdvice);
+                    if (longHistogramBuilder instanceof ExtendedLongHistogramBuilder) {
+                        Optional.ofNullable(histogramKey.attributes).ifPresent(((ExtendedLongHistogramBuilder) longHistogramBuilder)::setAttributesAdvice);
+                    }
+                    logger.log(Level.FINE, () -> "Reconfiguring long histogram " + histogramKey.name);
+                    reconfigurableLongHistogram.setDelegate(longHistogramBuilder.build());
+                });
+                // Double histograms
+                this.doubleHistograms.forEach((counterKey, reconfigurableDoubleHistogram) -> {
+                    DoubleHistogramBuilder doubleHistogramBuilder = delegate.histogramBuilder(counterKey.name);
+                    Optional.ofNullable(counterKey.description).ifPresent(doubleHistogramBuilder::setDescription);
+                    Optional.ofNullable(counterKey.unit).ifPresent(doubleHistogramBuilder::setUnit);
+                    Optional.ofNullable(counterKey.bucketBoundaries).ifPresent(doubleHistogramBuilder::setExplicitBucketBoundariesAdvice);
+                    if (doubleHistogramBuilder instanceof ExtendedDoubleHistogramBuilder) {
+                        Optional.ofNullable(counterKey.attributes).ifPresent(((ExtendedDoubleHistogramBuilder) doubleHistogramBuilder)::setAttributesAdvice);
+                    }
+                    logger.log(Level.FINE, () -> "Reconfiguring double histogram " + counterKey.name);
+                    reconfigurableDoubleHistogram.setDelegate(doubleHistogramBuilder.build());
+                });
+
+                // BATCH CALLBACKS
+                this.batchCallbacks.forEach((batchCallbackKey, reconfigurableBatchCallback) -> {
+
+                    // close previous call back to prevent
+                    // "WARNING	i.o.s.internal.ThrottlingLogger#doLog: Instrument xyz has recorded multiple values for the same attributes: {...}"
+                    reconfigurableBatchCallback.close();
+
+                    // io.opentelemetry.sdk.metrics.SdkMeter.batchCallback require the original ObservableMeasurement
+                    // see https://github.com/open-telemetry/opentelemetry-java/blob/v1.39.0/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java#L130
+
+                    ObservableMeasurement originalObservableMeasurement = ((ReconfigurableObservableMeasurement<?>) batchCallbackKey.observableMeasurement).getDelegate();
+                    ObservableMeasurement[] originalAdditionalMeasurements = Arrays.stream(batchCallbackKey.additionalObservableMeasurements).map(additionalMeasurement -> ((ReconfigurableObservableMeasurement<? extends ObservableMeasurement>) additionalMeasurement).getDelegate()).toArray(ObservableMeasurement[]::new);
+
+                    logger.log(Level.FINE, () -> "Reconfiguring batch callback " + batchCallbackKey.observableMeasurement + " " + Arrays.toString(batchCallbackKey.additionalObservableMeasurements));
+                    reconfigurableBatchCallback.setDelegate(delegate.batchCallback(batchCallbackKey.callback, originalObservableMeasurement, originalAdditionalMeasurements));
+                });
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        public synchronized Meter getDelegate() {
+            lock.readLock().lock();
+            try {
+                return delegate;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    @VisibleForTesting
+    protected static class ReconfigurableObservableLongMeasurement implements ObservableLongMeasurement, ReconfigurableObservableMeasurement<ObservableLongMeasurement> {
+        final ReadWriteLock lock;
+        private ObservableLongMeasurement delegate;
+
+        ReconfigurableObservableLongMeasurement(ObservableLongMeasurement delegate, ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.lock = lock;
+        }
+
+        @Override
+        public void record(long value) {
+            lock.readLock().lock();
+            try {
+                delegate.record(value);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void record(long value, Attributes attributes) {
+            lock.readLock().lock();
+            try {
+                delegate.record(value, attributes);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public ObservableLongMeasurement getDelegate() {
+            lock.readLock().lock();
+            try {
+                return delegate;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void setDelegate(ObservableLongMeasurement delegate) {
+            lock.writeLock().lock();
+            try {
+                this.delegate = delegate;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "ReconfigurableObservableLongMeasurement{" +
+                "delegate=" + delegate +
+                '}';
+        }
+    }
+
+    static class ReconfigurableLongCounterBuilder implements LongCounterBuilder {
+        final ReadWriteLock lock;
+        LongCounterBuilder delegate;
+        final ConcurrentMap<InstrumentKey, ReconfigurableLongCounter> longCounters;
+        final ConcurrentMap<ObservableLongMeasurementCallbackKey, ReconfigurableObservableLongCounter> observableLongCounters;
+        final ConcurrentMap<InstrumentKey, ReconfigurableObservableLongMeasurement> observableLongMeasurements;
+        final ConcurrentMap<InstrumentKey, ReconfigurableDoubleCounter> doubleCounters;
+        final ConcurrentMap<ObservableDoubleMeasurementCallbackKey, ReconfigurableObservableDoubleCounter> observableDoubleCounters;
+        final ConcurrentMap<InstrumentKey, ReconfigurableObservableDoubleMeasurement> observableDoubleMeasurements;
+
+        final String name;
+        String description;
+        String unit;
+
+
+        ReconfigurableLongCounterBuilder(LongCounterBuilder delegate, String name,
+                                         ConcurrentMap<InstrumentKey, ReconfigurableLongCounter> longCounters,
+                                         ConcurrentMap<InstrumentKey, ReconfigurableDoubleCounter> doubleCounters,
+                                         ConcurrentMap<ObservableLongMeasurementCallbackKey, ReconfigurableObservableLongCounter> observableLongCounters,
+                                         ConcurrentMap<InstrumentKey, ReconfigurableObservableLongMeasurement> observableLongMeasurements,
+                                         ConcurrentMap<ObservableDoubleMeasurementCallbackKey, ReconfigurableObservableDoubleCounter> observableDoubleCounters,
+                                         ConcurrentMap<InstrumentKey, ReconfigurableObservableDoubleMeasurement> observableDoubleMeasurements,
+                                         ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.name = name;
+            this.longCounters = longCounters;
+            this.observableLongCounters = observableLongCounters;
+            this.observableLongMeasurements = observableLongMeasurements;
+            this.doubleCounters = doubleCounters;
+            this.observableDoubleCounters = observableDoubleCounters;
+            this.observableDoubleMeasurements = observableDoubleMeasurements;
+
+            this.lock = lock;
+        }
+
+        @Override
+        public LongCounterBuilder setDescription(String description) {
+            lock.readLock().lock();
+            try {
+                delegate.setDescription(description);
+                this.description = description;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public LongCounterBuilder setUnit(String unit) {
+            lock.readLock().lock();
+            try {
+                delegate.setUnit(unit);
+                this.unit = unit;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public DoubleCounterBuilder ofDoubles() {
+            lock.readLock().lock();
+            try {
+                ReconfigurableDoubleCounterBuilder reconfigurableDoubleCounterBuilder = new ReconfigurableDoubleCounterBuilder(delegate.ofDoubles(), name, doubleCounters, observableDoubleCounters, observableDoubleMeasurements, lock);
+                Optional.ofNullable(description).ifPresent(reconfigurableDoubleCounterBuilder::setDescription);
+                Optional.ofNullable(unit).ifPresent(reconfigurableDoubleCounterBuilder::setUnit);
+                return reconfigurableDoubleCounterBuilder;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public LongCounter build() {
+            lock.readLock().lock();
+            try {
+                InstrumentKey counterKey = new InstrumentKey(name, description, unit);
+                return longCounters.computeIfAbsent(counterKey, k -> new ReconfigurableLongCounter(delegate.build(), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public ObservableLongCounter buildWithCallback(Consumer<ObservableLongMeasurement> callback) {
+            lock.readLock().lock();
+            try {
+                ObservableLongMeasurementCallbackKey key = new ObservableLongMeasurementCallbackKey(name, description, unit, callback);
+                return this.observableLongCounters.computeIfAbsent(key, k -> new ReconfigurableObservableLongCounter(delegate.buildWithCallback(callback), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public ObservableLongMeasurement buildObserver() {
+            lock.readLock().lock();
+            try {
+                InstrumentKey counterKey = new InstrumentKey(name, description, unit);
+                return this.observableLongMeasurements.computeIfAbsent(counterKey, k -> new ReconfigurableObservableLongMeasurement(delegate.buildObserver(), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    @VisibleForTesting
+    @ThreadSafe
+    protected static class ReconfigurableLongCounter implements LongCounter {
+        final ReadWriteLock lock;
+        @GuardedBy("lock")
+        private LongCounter delegate;
+
+        ReconfigurableLongCounter(LongCounter delegate, ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.lock = lock;
+        }
+
+        @Override
+        public void add(long increment) {
+            lock.readLock().lock();
+            try {
+                delegate.add(increment);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void add(long value, Attributes attributes) {
+            lock.readLock().lock();
+            try {
+                delegate.add(value, attributes);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void add(long value, Attributes attributes, Context context) {
+            lock.readLock().lock();
+            try {
+                delegate.add(value, attributes, context);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        public void setDelegate(LongCounter delegate) {
+            lock.writeLock().lock();
+            try {
+                this.delegate = delegate;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        public LongCounter getDelegate() {
+            lock.readLock().lock();
+            try {
+                return delegate;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    @VisibleForTesting
+    protected static class ReconfigurableObservableLongCounter implements ObservableLongCounter {
+        final ReadWriteLock lock;
+        ObservableLongCounter delegate;
+
+        ReconfigurableObservableLongCounter(ObservableLongCounter delegate, ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.lock = lock;
+        }
+
+        public void setDelegate(ObservableLongCounter delegate) {
+            lock.writeLock().lock();
+            try {
+                this.delegate = delegate;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        @Override
+        public void close() {
+            lock.readLock().lock();
+            try {
+                delegate.close();
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+    }
+
+    static class ReconfigurableDoubleCounterBuilder implements DoubleCounterBuilder {
+        final ReadWriteLock lock;
+        DoubleCounterBuilder delegate;
+        final ConcurrentMap<InstrumentKey, ReconfigurableDoubleCounter> doubleCounters;
+        final ConcurrentMap<ObservableDoubleMeasurementCallbackKey, ReconfigurableObservableDoubleCounter> observableDoubleCounters;
+        final ConcurrentMap<InstrumentKey, ReconfigurableObservableDoubleMeasurement> observableDoubleMeasurements;
+        final String name;
+        String description;
+        String unit;
+
+        ReconfigurableDoubleCounterBuilder(DoubleCounterBuilder delegate, String name,
+                                           ConcurrentMap<InstrumentKey, ReconfigurableDoubleCounter> doubleCounters,
+                                           ConcurrentMap<ObservableDoubleMeasurementCallbackKey, ReconfigurableObservableDoubleCounter> observableDoubleCounters,
+                                           ConcurrentMap<InstrumentKey, ReconfigurableObservableDoubleMeasurement> observableDoubleMeasurements,
+                                           ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.name = name;
+            this.doubleCounters = doubleCounters;
+            this.observableDoubleCounters = observableDoubleCounters;
+            this.observableDoubleMeasurements = observableDoubleMeasurements;
+            this.lock = lock;
+        }
+
+        @Override
+        public DoubleCounterBuilder setDescription(String description) {
+            lock.readLock().lock();
+            try {
+                delegate.setDescription(description);
+                this.description = description;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public DoubleCounterBuilder setUnit(String unit) {
+            lock.readLock().lock();
+            try {
+                delegate.setUnit(unit);
+                this.unit = unit;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public DoubleCounter build() {
+            lock.readLock().lock();
+            try {
+                InstrumentKey counterKey = new InstrumentKey(name, description, unit);
+                return doubleCounters.computeIfAbsent(counterKey, k -> new ReconfigurableDoubleCounter(delegate.build(), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public ObservableDoubleCounter buildWithCallback(Consumer<ObservableDoubleMeasurement> callback) {
+            lock.readLock().lock();
+            try {
+                ObservableDoubleMeasurementCallbackKey key = new ObservableDoubleMeasurementCallbackKey(name, description, unit, callback);
+                return this.observableDoubleCounters.computeIfAbsent(key, k -> new ReconfigurableObservableDoubleCounter(delegate.buildWithCallback(callback), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public ObservableDoubleMeasurement buildObserver() {
+            lock.readLock().lock();
+            try {
+                InstrumentKey key = new InstrumentKey(name, description, unit);
+                return this.observableDoubleMeasurements.computeIfAbsent(key, k -> new ReconfigurableObservableDoubleMeasurement(delegate.buildObserver(), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    static class ReconfigurableObservableDoubleCounter implements ObservableDoubleCounter {
+        final ReadWriteLock lock;
+        ObservableDoubleCounter delegate;
+
+        ReconfigurableObservableDoubleCounter(ObservableDoubleCounter delegate, ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.lock = lock;
+        }
+
+        public void setDelegate(ObservableDoubleCounter delegate) {
+            lock.writeLock().lock();
+            try {
+                this.delegate = delegate;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        public ObservableDoubleCounter getDelegate() {
+            lock.readLock().lock();
+            try {
+                return delegate;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void close() {
+            lock.readLock().lock();
+            try {
+                delegate.close();
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    @VisibleForTesting
+    @ThreadSafe
+    protected static class ReconfigurableDoubleCounter implements DoubleCounter {
+        final ReadWriteLock lock;
+        @GuardedBy("lock")
+        private DoubleCounter delegate;
+
+        ReconfigurableDoubleCounter(DoubleCounter delegate, ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.lock = lock;
+        }
+
+        @Override
+        public void add(double increment) {
+            lock.readLock().lock();
+            try {
+                delegate.add(increment);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void add(double value, Attributes attributes) {
+            lock.readLock().lock();
+            try {
+                delegate.add(value, attributes);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void add(double value, Attributes attributes, Context context) {
+            lock.readLock().lock();
+            try {
+                delegate.add(value, attributes, context);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        public void setDelegate(DoubleCounter delegate) {
+            lock.writeLock().lock();
+            try {
+                this.delegate = delegate;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        public DoubleCounter getDelegate() {
+            lock.readLock().lock();
+            try {
+                return delegate;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+
+    static class ReconfigurableDoubleGaugeBuilder implements DoubleGaugeBuilder {
+        final ReadWriteLock lock;
+        DoubleGaugeBuilder delegate;
+        final ConcurrentMap<InstrumentKey, ReconfigurableDoubleGauge> doubleGauges;
+        final ConcurrentMap<ObservableDoubleMeasurementCallbackKey, ReconfigurableObservableDoubleGauge> observableDoubleGauges;
+        final ConcurrentMap<InstrumentKey, ReconfigurableObservableDoubleMeasurement> observableDoubleMeasurements;
+        final ConcurrentMap<InstrumentKey, ReconfigurableLongGauge> longGauges;
+        final ConcurrentMap<ObservableLongMeasurementCallbackKey, ReconfigurableObservableLongGauge> observableLongGauges;
+        final ConcurrentMap<InstrumentKey, ReconfigurableObservableLongMeasurement> observableLongMeasurements;
+
+        final String name;
+        String description;
+        String unit;
+
+        ReconfigurableDoubleGaugeBuilder(
+            DoubleGaugeBuilder delegate, String name, ConcurrentMap<InstrumentKey,
+            ReconfigurableDoubleGauge> doubleGauges,
+            ConcurrentMap<ObservableDoubleMeasurementCallbackKey, ReconfigurableObservableDoubleGauge> observableDoubleGauges, ConcurrentMap<InstrumentKey, ReconfigurableObservableDoubleMeasurement> observableDoubleMeasurements, ConcurrentMap<InstrumentKey, ReconfigurableLongGauge> longGauges, ConcurrentMap<ObservableLongMeasurementCallbackKey, ReconfigurableObservableLongGauge> observableLongGauges,
+            ConcurrentMap<InstrumentKey, ReconfigurableObservableLongMeasurement> observableLongMeasurements,
+            ReadWriteLock lock) {
+
+            this.delegate = delegate;
+            this.name = name;
+            this.doubleGauges = doubleGauges;
+            this.observableDoubleGauges = observableDoubleGauges;
+            this.observableDoubleMeasurements = observableDoubleMeasurements;
+            this.observableLongGauges = observableLongGauges;
+            this.observableLongMeasurements = observableLongMeasurements;
+            this.longGauges = longGauges;
+
+            this.lock = lock;
+        }
+
+        @Override
+        public DoubleGaugeBuilder setDescription(String description) {
+            lock.readLock().lock();
+            try {
+                delegate.setDescription(description);
+                this.description = description;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public DoubleGaugeBuilder setUnit(String unit) {
+            lock.readLock().lock();
+            try {
+                delegate.setUnit(unit);
+                this.unit = unit;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public LongGaugeBuilder ofLongs() {
+            lock.readLock().lock();
+            try {
+                ReconfigurableLongGaugeBuilder reconfigurableLongCounterBuilder = new ReconfigurableLongGaugeBuilder(delegate.ofLongs(), name, longGauges, observableLongGauges, observableLongMeasurements, lock);
+                Optional.ofNullable(description).ifPresent(reconfigurableLongCounterBuilder::setDescription);
+                Optional.ofNullable(unit).ifPresent(reconfigurableLongCounterBuilder::setUnit);
+                return reconfigurableLongCounterBuilder;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public DoubleGauge build() {
+            lock.readLock().lock();
+            try {
+                InstrumentKey gaugeKey = new InstrumentKey(name, description, unit);
+                return doubleGauges.computeIfAbsent(gaugeKey, k -> new ReconfigurableDoubleGauge(delegate.build(), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public ObservableDoubleGauge buildWithCallback(Consumer<ObservableDoubleMeasurement> callback) {
+            lock.readLock().lock();
+            try {
+                ObservableDoubleMeasurementCallbackKey key = new ObservableDoubleMeasurementCallbackKey(name, description, unit, callback);
+                return this.observableDoubleGauges.computeIfAbsent(key, k -> new ReconfigurableObservableDoubleGauge(delegate.buildWithCallback(callback), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public ObservableDoubleMeasurement buildObserver() {
+            lock.readLock().lock();
+            try {
+                InstrumentKey gaugeKey = new InstrumentKey(name, description, unit);
+                return this.observableDoubleMeasurements.computeIfAbsent(gaugeKey, k -> new ReconfigurableObservableDoubleMeasurement(delegate.buildObserver(), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+    }
+
+    static class ReconfigurableLongGaugeBuilder implements LongGaugeBuilder {
+        final ReadWriteLock lock;
+        LongGaugeBuilder delegate;
+        final ConcurrentMap<InstrumentKey, ReconfigurableLongGauge> longGauges;
+        final ConcurrentMap<ObservableLongMeasurementCallbackKey, ReconfigurableObservableLongGauge> observableLongGauges;
+        final ConcurrentMap<InstrumentKey, ReconfigurableObservableLongMeasurement> observableLongMeasurements;
+
+        final String name;
+        String description;
+        String unit;
+
+
+        ReconfigurableLongGaugeBuilder(LongGaugeBuilder delegate, String name,
+                                       ConcurrentMap<InstrumentKey, ReconfigurableLongGauge> longGauges,
+                                       ConcurrentMap<ObservableLongMeasurementCallbackKey, ReconfigurableObservableLongGauge> observableLongGauges,
+                                       ConcurrentMap<InstrumentKey, ReconfigurableObservableLongMeasurement> observableLongMeasurements,
+                                       ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.name = name;
+            this.longGauges = longGauges;
+            this.observableLongGauges = observableLongGauges;
+            this.observableLongMeasurements = observableLongMeasurements;
+
+            this.lock = lock;
+        }
+
+        @Override
+        public LongGaugeBuilder setDescription(String description) {
+            lock.readLock().lock();
+            try {
+                delegate.setDescription(description);
+                this.description = description;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public LongGaugeBuilder setUnit(String unit) {
+            lock.readLock().lock();
+            try {
+                delegate.setUnit(unit);
+                this.unit = unit;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public LongGauge build() {
+            lock.readLock().lock();
+            try {
+                InstrumentKey counterKey = new InstrumentKey(name, description, unit);
+                return longGauges.computeIfAbsent(counterKey, k -> new ReconfigurableLongGauge(delegate.build(), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public ObservableLongGauge buildWithCallback(Consumer<ObservableLongMeasurement> callback) {
+            lock.readLock().lock();
+            try {
+                ObservableLongMeasurementCallbackKey key = new ObservableLongMeasurementCallbackKey(name, description, unit, callback);
+                return this.observableLongGauges.computeIfAbsent(key, k -> new ReconfigurableObservableLongGauge(delegate.buildWithCallback(callback), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public ObservableLongMeasurement buildObserver() {
+            lock.readLock().lock();
+            try {
+                InstrumentKey counterKey = new InstrumentKey(name, description, unit);
+                return this.observableLongMeasurements.computeIfAbsent(counterKey, k -> new ReconfigurableObservableLongMeasurement(delegate.buildObserver(), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    @VisibleForTesting
+    @ThreadSafe
+    protected static class ReconfigurableLongGauge implements LongGauge {
+        final ReadWriteLock lock;
+        @GuardedBy("lock")
+        private LongGauge delegate;
+
+        ReconfigurableLongGauge(LongGauge delegate, ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.lock = lock;
+        }
+
+        @Override
+        public void set(long value) {
+            lock.readLock().lock();
+            try {
+                delegate.set(value);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void set(long value, Attributes attributes) {
+            lock.readLock().lock();
+            try {
+                delegate.set(value, attributes);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void set(long value, Attributes attributes, Context context) {
+            lock.readLock().lock();
+            try {
+                delegate.set(value, attributes, context);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        public void setDelegate(LongGauge delegate) {
+            lock.writeLock().lock();
+            try {
+                this.delegate = delegate;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        public LongGauge getDelegate() {
+            lock.readLock().lock();
+            try {
+                return delegate;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    @VisibleForTesting
+    protected static class ReconfigurableObservableLongGauge implements ObservableLongGauge {
+        final ReadWriteLock lock;
+        ObservableLongGauge delegate;
+
+        ReconfigurableObservableLongGauge(ObservableLongGauge delegate, ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.lock = lock;
+        }
+
+        public void setDelegate(ObservableLongGauge delegate) {
+            lock.writeLock().lock();
+            try {
+                this.delegate = delegate;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        @Override
+        public void close() {
+            lock.readLock().lock();
+            try {
+                delegate.close();
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    @VisibleForTesting
+    @ThreadSafe
+    protected static class ReconfigurableDoubleGauge implements DoubleGauge {
+        final ReadWriteLock lock;
+        @GuardedBy("lock")
+        private DoubleGauge delegate;
+
+        ReconfigurableDoubleGauge(DoubleGauge delegate, ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.lock = lock;
+        }
+
+        @Override
+        public void set(double value) {
+            lock.readLock().lock();
+            try {
+                delegate.set(value);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void set(double value, Attributes attributes) {
+            lock.readLock().lock();
+            try {
+                delegate.set(value, attributes);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void set(double value, Attributes attributes, Context context) {
+            lock.readLock().lock();
+            try {
+                delegate.set(value, attributes, context);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        public void setDelegate(DoubleGauge delegate) {
+            lock.writeLock().lock();
+            try {
+                this.delegate = delegate;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        public DoubleGauge getDelegate() {
+            lock.readLock().lock();
+            try {
+                return delegate;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    @VisibleForTesting
+    protected static class ReconfigurableObservableDoubleGauge implements ObservableDoubleGauge {
+        final ReadWriteLock lock;
+        ObservableDoubleGauge delegate;
+
+        ReconfigurableObservableDoubleGauge(ObservableDoubleGauge delegate, ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.lock = lock;
+        }
+
+        public void setDelegate(ObservableDoubleGauge delegate) {
+            lock.writeLock().lock();
+            try {
+                this.delegate = delegate;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        @Override
+        public void close() {
+            lock.readLock().lock();
+            try {
+                delegate.close();
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    @VisibleForTesting
+    protected static class ReconfigurableObservableDoubleMeasurement implements ObservableDoubleMeasurement, ReconfigurableObservableMeasurement<ObservableDoubleMeasurement> {
+        final ReadWriteLock lock;
+        private ObservableDoubleMeasurement delegate;
+
+        ReconfigurableObservableDoubleMeasurement(ObservableDoubleMeasurement delegate, ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.lock = lock;
+        }
+
+        @Override
+        public void record(double value) {
+            lock.readLock().lock();
+            try {
+                delegate.record(value);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void record(double value, Attributes attributes) {
+            lock.readLock().lock();
+            try {
+                delegate.record(value, attributes);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public ObservableDoubleMeasurement getDelegate() {
+            lock.readLock().lock();
+            try {
+                return delegate;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void setDelegate(ObservableDoubleMeasurement delegate) {
+            lock.writeLock().lock();
+            try {
+                this.delegate = delegate;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+    }
+
+    @VisibleForTesting
+    @ThreadSafe
+    protected static class ReconfigurableLongUpDownCounter implements LongUpDownCounter {
+        final ReadWriteLock lock;
+        @GuardedBy("lock")
+        private LongUpDownCounter delegate;
+
+        ReconfigurableLongUpDownCounter(LongUpDownCounter delegate, ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.lock = lock;
+        }
+
+        @Override
+        public void add(long increment) {
+            lock.readLock().lock();
+            try {
+                delegate.add(increment);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void add(long value, Attributes attributes) {
+            lock.readLock().lock();
+            try {
+                delegate.add(value, attributes);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void add(long value, Attributes attributes, Context context) {
+            lock.readLock().lock();
+            try {
+                delegate.add(value, attributes, context);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        public void setDelegate(LongUpDownCounter delegate) {
+            lock.writeLock().lock();
+            try {
+                this.delegate = delegate;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        public LongUpDownCounter getDelegate() {
+            lock.readLock().lock();
+            try {
+                return delegate;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    @VisibleForTesting
+    @ThreadSafe
+    protected static class ReconfigurableDoubleUpDownCounter implements DoubleUpDownCounter {
+        final ReadWriteLock lock;
+        @GuardedBy("lock")
+        private DoubleUpDownCounter delegate;
+
+        ReconfigurableDoubleUpDownCounter(DoubleUpDownCounter delegate, ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.lock = lock;
+        }
+
+        @Override
+        public void add(double increment) {
+            lock.readLock().lock();
+            try {
+                delegate.add(increment);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void add(double value, Attributes attributes) {
+            lock.readLock().lock();
+            try {
+                delegate.add(value, attributes);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void add(double value, Attributes attributes, Context context) {
+            lock.readLock().lock();
+            try {
+                delegate.add(value, attributes, context);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        public void setDelegate(DoubleUpDownCounter delegate) {
+            lock.writeLock().lock();
+            try {
+                this.delegate = delegate;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        public DoubleUpDownCounter getDelegate() {
+            lock.readLock().lock();
+            try {
+                return delegate;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    static class ReconfigurableLongUpDownCounterBuilder implements LongUpDownCounterBuilder {
+        final ReadWriteLock lock;
+        LongUpDownCounterBuilder delegate;
+        final ConcurrentMap<InstrumentKey, ReconfigurableLongUpDownCounter> longUpDownCounters;
+        final ConcurrentMap<ObservableLongMeasurementCallbackKey, ReconfigurableObservableLongUpDownCounter> observableLongUpDownCounters;
+        final ConcurrentMap<InstrumentKey, ReconfigurableObservableLongMeasurement> observableLongMeasurements;
+        final ConcurrentMap<InstrumentKey, ReconfigurableDoubleUpDownCounter> doubleUpDownCounters;
+        final ConcurrentMap<ObservableDoubleMeasurementCallbackKey, ReconfigurableObservableDoubleUpDownCounter> observableDoubleUpDownCounters;
+        final ConcurrentMap<InstrumentKey, ReconfigurableObservableDoubleMeasurement> observableDoubleMeasurements;
+
+        final String name;
+        String description;
+        String unit;
+
+
+        ReconfigurableLongUpDownCounterBuilder(LongUpDownCounterBuilder delegate, String name,
+                                               ConcurrentMap<InstrumentKey, ReconfigurableLongUpDownCounter> longUpDownCounters,
+                                               ConcurrentMap<InstrumentKey, ReconfigurableDoubleUpDownCounter> doubleUpDownCounters,
+                                               ConcurrentMap<ObservableLongMeasurementCallbackKey, ReconfigurableObservableLongUpDownCounter> observableLongUpDownCounters,
+                                               ConcurrentMap<InstrumentKey, ReconfigurableObservableLongMeasurement> observableLongMeasurements,
+                                               ConcurrentMap<ObservableDoubleMeasurementCallbackKey, ReconfigurableObservableDoubleUpDownCounter> observableDoubleUpDownCounters,
+                                               ConcurrentMap<InstrumentKey, ReconfigurableObservableDoubleMeasurement> observableDoubleMeasurements,
+                                               ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.name = name;
+            this.longUpDownCounters = longUpDownCounters;
+            this.observableLongUpDownCounters = observableLongUpDownCounters;
+            this.observableLongMeasurements = observableLongMeasurements;
+            this.doubleUpDownCounters = doubleUpDownCounters;
+            this.observableDoubleUpDownCounters = observableDoubleUpDownCounters;
+            this.observableDoubleMeasurements = observableDoubleMeasurements;
+
+            this.lock = lock;
+        }
+
+        @Override
+        public LongUpDownCounterBuilder setDescription(String description) {
+            lock.readLock().lock();
+            try {
+                delegate.setDescription(description);
+                this.description = description;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public LongUpDownCounterBuilder setUnit(String unit) {
+            lock.readLock().lock();
+            try {
+                delegate.setUnit(unit);
+                this.unit = unit;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public DoubleUpDownCounterBuilder ofDoubles() {
+            lock.readLock().lock();
+            try {
+                ReconfigurableDoubleUpDownCounterBuilder reconfigurableDoubleCounterBuilder = new ReconfigurableDoubleUpDownCounterBuilder(delegate.ofDoubles(), name, doubleUpDownCounters, observableDoubleUpDownCounters, observableDoubleMeasurements, lock);
+                Optional.ofNullable(description).ifPresent(reconfigurableDoubleCounterBuilder::setDescription);
+                Optional.ofNullable(unit).ifPresent(reconfigurableDoubleCounterBuilder::setUnit);
+                return reconfigurableDoubleCounterBuilder;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public LongUpDownCounter build() {
+            lock.readLock().lock();
+            try {
+                InstrumentKey counterKey = new InstrumentKey(name, description, unit);
+                return longUpDownCounters.computeIfAbsent(counterKey, k -> new ReconfigurableLongUpDownCounter(delegate.build(), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public ObservableLongUpDownCounter buildWithCallback(Consumer<ObservableLongMeasurement> callback) {
+            lock.readLock().lock();
+            try {
+                ObservableLongMeasurementCallbackKey key = new ObservableLongMeasurementCallbackKey(name, description, unit, callback);
+                return this.observableLongUpDownCounters.computeIfAbsent(key, k -> new ReconfigurableObservableLongUpDownCounter(delegate.buildWithCallback(callback), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public ObservableLongMeasurement buildObserver() {
+            lock.readLock().lock();
+            try {
+                InstrumentKey counterKey = new InstrumentKey(name, description, unit);
+                return this.observableLongMeasurements.computeIfAbsent(counterKey, k -> new ReconfigurableObservableLongMeasurement(delegate.buildObserver(), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    @VisibleForTesting
+    protected static class ReconfigurableObservableLongUpDownCounter implements ObservableLongUpDownCounter {
+        final ReadWriteLock lock;
+        ObservableLongUpDownCounter delegate;
+
+        ReconfigurableObservableLongUpDownCounter(ObservableLongUpDownCounter delegate, ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.lock = lock;
+        }
+
+        public void setDelegate(ObservableLongUpDownCounter delegate) {
+            lock.writeLock().lock();
+            try {
+                this.delegate = delegate;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        @Override
+        public void close() {
+            lock.readLock().lock();
+            try {
+                delegate.close();
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    static class ReconfigurableObservableDoubleUpDownCounter implements ObservableDoubleUpDownCounter {
+        final ReadWriteLock lock;
+        ObservableDoubleUpDownCounter delegate;
+
+        ReconfigurableObservableDoubleUpDownCounter(ObservableDoubleUpDownCounter delegate, ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.lock = lock;
+        }
+
+        public void setDelegate(ObservableDoubleUpDownCounter delegate) {
+            lock.writeLock().lock();
+            try {
+                this.delegate = delegate;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        public ObservableDoubleUpDownCounter getDelegate() {
+            lock.readLock().lock();
+            try {
+                return delegate;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void close() {
+            lock.readLock().lock();
+            try {
+                delegate.close();
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    static class ReconfigurableDoubleUpDownCounterBuilder implements DoubleUpDownCounterBuilder {
+        final ReadWriteLock lock;
+        DoubleUpDownCounterBuilder delegate;
+        final ConcurrentMap<InstrumentKey, ReconfigurableDoubleUpDownCounter> doubleUpDownCounters;
+        final ConcurrentMap<ObservableDoubleMeasurementCallbackKey, ReconfigurableObservableDoubleUpDownCounter> observableDoubleUpDownCounters;
+        final ConcurrentMap<InstrumentKey, ReconfigurableObservableDoubleMeasurement> observableDoubleMeasurements;
+        final String name;
+        String description;
+        String unit;
+
+        ReconfigurableDoubleUpDownCounterBuilder(DoubleUpDownCounterBuilder delegate, String name,
+                                                 ConcurrentMap<InstrumentKey, ReconfigurableDoubleUpDownCounter> doubleUpDownCounters,
+                                                 ConcurrentMap<ObservableDoubleMeasurementCallbackKey, ReconfigurableObservableDoubleUpDownCounter> observableDoubleUpDownCounters,
+                                                 ConcurrentMap<InstrumentKey, ReconfigurableObservableDoubleMeasurement> observableDoubleMeasurements,
+                                                 ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.name = name;
+            this.doubleUpDownCounters = doubleUpDownCounters;
+            this.observableDoubleUpDownCounters = observableDoubleUpDownCounters;
+            this.observableDoubleMeasurements = observableDoubleMeasurements;
+            this.lock = lock;
+        }
+
+        @Override
+        public DoubleUpDownCounterBuilder setDescription(String description) {
+            lock.readLock().lock();
+            try {
+                delegate.setDescription(description);
+                this.description = description;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public DoubleUpDownCounterBuilder setUnit(String unit) {
+            lock.readLock().lock();
+            try {
+                delegate.setUnit(unit);
+                this.unit = unit;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public DoubleUpDownCounter build() {
+            lock.readLock().lock();
+            try {
+                InstrumentKey counterKey = new InstrumentKey(name, description, unit);
+                return doubleUpDownCounters.computeIfAbsent(counterKey, k -> new ReconfigurableDoubleUpDownCounter(delegate.build(), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public ObservableDoubleUpDownCounter buildWithCallback(Consumer<ObservableDoubleMeasurement> callback) {
+            lock.readLock().lock();
+            try {
+                ObservableDoubleMeasurementCallbackKey key = new ObservableDoubleMeasurementCallbackKey(name, description, unit, callback);
+                return this.observableDoubleUpDownCounters.computeIfAbsent(key, k -> new ReconfigurableObservableDoubleUpDownCounter(delegate.buildWithCallback(callback), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public ObservableDoubleMeasurement buildObserver() {
+            lock.readLock().lock();
+            try {
+                InstrumentKey key = new InstrumentKey(name, description, unit);
+                return this.observableDoubleMeasurements.computeIfAbsent(key, k -> new ReconfigurableObservableDoubleMeasurement(delegate.buildObserver(), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    static class ReconfigurableBatchCallback implements BatchCallback {
+        final ReadWriteLock lock;
+        BatchCallback delegate;
+
+        ReconfigurableBatchCallback(BatchCallback delegate, ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.lock = lock;
+        }
+
+        @Override
+        public void close() {
+            lock.readLock().lock();
+            try {
+                delegate.close();
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        public void setDelegate(BatchCallback delegate) {
+            lock.writeLock().lock();
+            try {
+                this.delegate = delegate;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+    }
+
+    static class BatchCallbackKey {
+        final Runnable callback;
+        final ObservableMeasurement observableMeasurement;
+        final ObservableMeasurement[] additionalObservableMeasurements;
+
+        public BatchCallbackKey(Runnable callback, ObservableMeasurement observableMeasurement, ObservableMeasurement... additionalObservableMeasurements) {
+            this.callback = callback;
+            this.observableMeasurement = Objects.requireNonNull(observableMeasurement);
+            this.additionalObservableMeasurements = Objects.requireNonNull(additionalObservableMeasurements);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            BatchCallbackKey that = (BatchCallbackKey) o;
+            return Objects.equals(callback, that.callback) && Objects.equals(observableMeasurement, that.observableMeasurement) && Objects.deepEquals(additionalObservableMeasurements, that.additionalObservableMeasurements);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(callback, observableMeasurement, Arrays.hashCode(additionalObservableMeasurements));
+        }
+    }
+
+    static class ReconfigurableDoubleHistogramBuilder implements ExtendedDoubleHistogramBuilder {
+        final ReadWriteLock lock;
+        DoubleHistogramBuilder delegate;
+        final ConcurrentMap<HistogramKey<Double>, ReconfigurableDoubleHistogram> doubleHistograms;
+        final ConcurrentMap<HistogramKey<Long>, ReconfigurableLongHistogram> longHistograms;
+
+        final String name;
+        String description;
+        String unit;
+        List<AttributeKey<?>> attributes;
+        List<Double> bucketBoundaries;
+
+        ReconfigurableDoubleHistogramBuilder(
+            DoubleHistogramBuilder delegate, String name,
+            ConcurrentMap<HistogramKey<Double>, ReconfigurableDoubleHistogram> doubleHistograms,
+            ConcurrentMap<HistogramKey<Long>, ReconfigurableLongHistogram> longHistograms,
+            ReadWriteLock lock) {
+
+            this.delegate = delegate;
+            this.name = name;
+            this.doubleHistograms = doubleHistograms;
+            this.longHistograms = longHistograms;
+
+            this.lock = lock;
+        }
+
+        @Override
+        public DoubleHistogramBuilder setDescription(String description) {
+            lock.readLock().lock();
+            try {
+                delegate.setDescription(description);
+                this.description = description;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public DoubleHistogramBuilder setUnit(String unit) {
+            lock.readLock().lock();
+            try {
+                delegate.setUnit(unit);
+                this.unit = unit;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public ExtendedDoubleHistogramBuilder setAttributesAdvice(List<AttributeKey<?>> attributes) {
+            lock.readLock().lock();
+            try {
+                if (delegate instanceof ExtendedDoubleHistogramBuilder) {
+                    ((ExtendedDoubleHistogramBuilder) delegate).setAttributesAdvice(attributes);
+                }
+                this.attributes = attributes;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public LongHistogramBuilder ofLongs() {
+            lock.readLock().lock();
+            try {
+                ReconfigurableLongHistogramBuilder reconfigurableLongCounterBuilder = new ReconfigurableLongHistogramBuilder(delegate.ofLongs(), name, longHistograms, lock);
+                Optional.ofNullable(description).ifPresent(reconfigurableLongCounterBuilder::setDescription);
+                Optional.ofNullable(unit).ifPresent(reconfigurableLongCounterBuilder::setUnit);
+                if (reconfigurableLongCounterBuilder.delegate instanceof ExtendedLongHistogramBuilder) {
+                    Optional.ofNullable(attributes).ifPresent(((ExtendedLongHistogramBuilder) reconfigurableLongCounterBuilder.delegate)::setAttributesAdvice);
+                }
+                return reconfigurableLongCounterBuilder;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public DoubleHistogram build() {
+            lock.readLock().lock();
+            try {
+                HistogramKey<Double> doubleHistogramKey = new HistogramKey<>(name, description, unit, attributes, bucketBoundaries);
+                return doubleHistograms.computeIfAbsent(doubleHistogramKey, k -> new ReconfigurableDoubleHistogram(delegate.build(), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public DoubleHistogramBuilder setExplicitBucketBoundariesAdvice(List<Double> bucketBoundaries) {
+            lock.readLock().lock();
+            try {
+                delegate.setExplicitBucketBoundariesAdvice(bucketBoundaries);
+                this.bucketBoundaries = bucketBoundaries;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    @VisibleForTesting
+    @ThreadSafe
+    protected static class ReconfigurableDoubleHistogram implements DoubleHistogram {
+        final ReadWriteLock lock;
+        @GuardedBy("lock")
+        private DoubleHistogram delegate;
+
+        ReconfigurableDoubleHistogram(DoubleHistogram delegate, ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.lock = lock;
+        }
+
+        @Override
+        public void record(double value) {
+            lock.readLock().lock();
+            try {
+                delegate.record(value);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void record(double value, Attributes attributes) {
+            lock.readLock().lock();
+            try {
+                delegate.record(value, attributes);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void record(double value, Attributes attributes, Context context) {
+            lock.readLock().lock();
+            try {
+                delegate.record(value, attributes, context);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        public void setDelegate(DoubleHistogram delegate) {
+            lock.writeLock().lock();
+            try {
+                this.delegate = delegate;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        public DoubleHistogram getDelegate() {
+            lock.readLock().lock();
+            try {
+                return delegate;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    static class ReconfigurableLongHistogramBuilder implements ExtendedLongHistogramBuilder {
+        final ReadWriteLock lock;
+        LongHistogramBuilder delegate;
+        final ConcurrentMap<HistogramKey<Long>, ReconfigurableLongHistogram> longHistograms;
+
+        final String name;
+        String description;
+        String unit;
+        List<Long> bucketBoundaries;
+        List<AttributeKey<?>> attributes;
+
+
+        ReconfigurableLongHistogramBuilder(LongHistogramBuilder delegate, String name,
+                                           ConcurrentMap<HistogramKey<Long>, ReconfigurableLongHistogram> longHistograms,
+                                           ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.name = name;
+            this.longHistograms = longHistograms;
+
+            this.lock = lock;
+        }
+
+        @Override
+        public LongHistogramBuilder setDescription(String description) {
+            lock.readLock().lock();
+            try {
+                delegate.setDescription(description);
+                this.description = description;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public LongHistogramBuilder setUnit(String unit) {
+            lock.readLock().lock();
+            try {
+                delegate.setUnit(unit);
+                this.unit = unit;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public ExtendedLongHistogramBuilder setAttributesAdvice(List<AttributeKey<?>> attributes) {
+            lock.readLock().lock();
+            try {
+                if (delegate instanceof ExtendedLongHistogramBuilder) {
+                    ((ExtendedLongHistogramBuilder) delegate).setAttributesAdvice(attributes);
+                }
+                this.attributes = attributes;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+
+        @Override
+        public LongHistogramBuilder setExplicitBucketBoundariesAdvice(List<Long> bucketBoundaries) {
+            lock.readLock().lock();
+            try {
+                delegate.setExplicitBucketBoundariesAdvice(bucketBoundaries);
+                this.bucketBoundaries = bucketBoundaries;
+                return this;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public LongHistogram build() {
+            lock.readLock().lock();
+            try {
+                HistogramKey<Long> longHistogramKey = new HistogramKey<>(name, description, unit, attributes, bucketBoundaries);
+                return longHistograms.computeIfAbsent(longHistogramKey, k -> new ReconfigurableLongHistogram(delegate.build(), lock));
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+    }
+
+    @VisibleForTesting
+    @ThreadSafe
+    protected static class ReconfigurableLongHistogram implements LongHistogram {
+        final ReadWriteLock lock;
+        @GuardedBy("lock")
+        private LongHistogram delegate;
+
+        ReconfigurableLongHistogram(LongHistogram delegate, ReadWriteLock lock) {
+            this.delegate = delegate;
+            this.lock = lock;
+        }
+
+        @Override
+        public void record(long value) {
+            lock.readLock().lock();
+            try {
+                delegate.record(value);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void record(long value, Attributes attributes) {
+            lock.readLock().lock();
+            try {
+                delegate.record(value, attributes);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void record(long value, Attributes attributes, Context context) {
+            lock.readLock().lock();
+            try {
+                delegate.record(value, attributes, context);
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        public void setDelegate(LongHistogram delegate) {
+            lock.writeLock().lock();
+            try {
+                this.delegate = delegate;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        public LongHistogram getDelegate() {
+            lock.readLock().lock();
+            try {
+                return delegate;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    interface ReconfigurableObservableMeasurement<T extends ObservableMeasurement> extends ObservableMeasurement {
+        void setDelegate(T delegate);
+
+        T getDelegate();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableOpenTelemetry.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableOpenTelemetry.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.api;
+
+import com.google.common.base.Function;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+import io.jenkins.plugins.opentelemetry.api.util.ConfigPropertiesUtils;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.incubator.events.EventLogger;
+import io.opentelemetry.api.incubator.events.EventLoggerBuilder;
+import io.opentelemetry.api.incubator.events.EventLoggerProvider;
+import io.opentelemetry.api.incubator.events.GlobalEventLoggerProvider;
+import io.opentelemetry.api.logs.LoggerProvider;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterBuilder;
+import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerBuilder;
+import io.opentelemetry.api.trace.TracerProvider;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.logs.internal.SdkEventLoggerProvider;
+import io.opentelemetry.sdk.resources.Resource;
+
+import javax.annotation.OverridingMethodsMustInvokeSuper;
+import javax.annotation.PreDestroy;
+import java.io.Closeable;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * <p>
+ * Reconfigurable {@link EventLoggerProvider} that allows to reconfigure the {@link Tracer}s,
+ * {@link io.opentelemetry.api.logs.Logger}s, and {@link EventLogger}s.
+ * </p>
+ * <p>
+ * We need reconfigurability because Jenkins supports changing the configuration of the OpenTelemetry params at runtime.
+ * All instantiated tracers, loggers, and eventLoggers are reconfigured when the configuration changes, when
+ * {@link ReconfigurableOpenTelemetry#configure(Map, Resource)} is invoked.
+ * </p>
+ */
+@Extension(ordinal = Integer.MAX_VALUE)
+public class ReconfigurableOpenTelemetry implements ExtendedOpenTelemetry, OpenTelemetry, Closeable, ExtensionPoint {
+
+    protected final Logger logger = Logger.getLogger(getClass().getName());
+    Resource resource = Resource.empty();
+    ConfigProperties config = ConfigPropertiesUtils.emptyConfig();
+    OpenTelemetry openTelemetryImpl = OpenTelemetry.noop();
+    final ReconfigurableMeterProvider meterProviderImpl = new ReconfigurableMeterProvider();
+    final ReconfigurableTracerProvider traceProviderImpl = new ReconfigurableTracerProvider();
+    final ReconfigurableLoggerProvider loggerProviderImpl = new ReconfigurableLoggerProvider();
+    final ReconfigurableEventLoggerProvider eventLoggerProviderImpl = new ReconfigurableEventLoggerProvider();
+
+    /**
+     * Initialize as NoOp
+     */
+    public ReconfigurableOpenTelemetry() {
+        try {
+            GlobalOpenTelemetry.set(this);
+        } catch (IllegalStateException e) {
+            logger.log(Level.WARNING, "GlobalOpenTelemetry already set", e);
+        }
+        try {
+            GlobalEventLoggerProvider.set(eventLoggerProviderImpl);
+        } catch (IllegalStateException e) {
+            logger.log(Level.WARNING, "GlobalEventLoggerProvider already set", e);
+        }
+
+        logger.log(Level.FINE, () -> "Initialize " +
+                "GlobalOpenTelemetry with instance " + Optional.of(GlobalOpenTelemetry.get()).map(ot -> ot + "@" + System.identityHashCode(ot)) + "and " +
+                "GlobalEventLoggerProvide with instance " + Optional.of(GlobalEventLoggerProvider.get()).map(elp -> elp + "@" + System.identityHashCode(elp)));
+    }
+
+    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.SYSTEM_CONFIG_LOADED)
+    public void init() {
+        logger.log(Level.INFO, "OpenTelemetry initialized as NoOp");
+    }
+
+    public void configure(@NonNull Map<String, String> openTelemetryProperties, Resource openTelemetryResource) {
+
+        if (openTelemetryProperties.containsKey("otel.exporter.otlp.endpoint") ||
+                openTelemetryProperties.containsKey("otel.traces.exporter") ||
+                openTelemetryProperties.containsKey("otel.metrics.exporter") ||
+                openTelemetryProperties.containsKey("otel.logs.exporter")) {
+
+            logger.log(Level.FINE, "initializeOtlp");
+
+            // OPENTELEMETRY SDK
+            OpenTelemetrySdk openTelemetrySdk = AutoConfiguredOpenTelemetrySdk
+                    .builder()
+                    // properties
+                    .addPropertiesSupplier(() -> openTelemetryProperties)
+                    .addPropertiesCustomizer((Function<ConfigProperties, Map<String, String>>) configProperties -> {
+                        // keep a reference to the computed config properties for future use in the plugin
+                        this.config = configProperties;
+                        return Collections.emptyMap();
+                    })
+                    // resource
+                    .addResourceCustomizer((resource1, configProperties) -> {
+                                // keep a reference to the computed Resource for future use in the plugin
+                                this.resource = Resource.builder()
+                                        .putAll(resource1)
+                                        .putAll(openTelemetryResource).build();
+                                return this.resource;
+                            }
+                    )
+                    // disable shutdown hook, SDK closed by #close()
+                    .disableShutdownHook()
+                    .build()
+                    .getOpenTelemetrySdk();
+
+            setOpenTelemetryImpl(openTelemetrySdk);
+
+            logger.log(Level.INFO, () -> "OpenTelemetry initialized: " + ConfigPropertiesUtils.prettyPrintOtelSdkConfig(this.config, this.resource));
+
+        } else { // NO-OP
+
+            this.resource = Resource.empty();
+            this.config = ConfigPropertiesUtils.emptyConfig();
+            setOpenTelemetryImpl(OpenTelemetry.noop());
+
+            logger.log(Level.INFO, "OpenTelemetry initialized as NoOp");
+        }
+
+        postOpenTelemetrySdkConfiguration();
+    }
+
+    protected void setOpenTelemetryImpl(OpenTelemetry openTelemetryImpl) {
+        if (this.openTelemetryImpl instanceof OpenTelemetrySdk) {
+            logger.log(Level.FINE, () -> "Shutdown OTel SDK...");
+            CompletableResultCode shutdown = ((OpenTelemetrySdk) this.openTelemetryImpl).shutdown();
+            if (!shutdown.join(1, TimeUnit.SECONDS).isSuccess()) {
+                logger.log(Level.WARNING, "Failure to shutdown OTel SDK");
+            }
+        }
+        this.openTelemetryImpl = openTelemetryImpl;
+        this.meterProviderImpl.setDelegate(openTelemetryImpl.getMeterProvider());
+        this.traceProviderImpl.setDelegate(openTelemetryImpl.getTracerProvider());
+        this.loggerProviderImpl.setDelegate(openTelemetryImpl.getLogsBridge());
+        this.eventLoggerProviderImpl.setDelegate(SdkEventLoggerProvider.create(openTelemetryImpl.getLogsBridge()));
+    }
+
+    @PreDestroy
+    @Override
+    public void close() {
+        logger.log(Level.FINE, "Shutdown...");
+        // OTEL SDK
+        if (this.openTelemetryImpl instanceof OpenTelemetrySdk) {
+            logger.log(Level.FINE, () -> "Shutdown OTel SDK...");
+            CompletableResultCode shutdown = ((OpenTelemetrySdk) this.openTelemetryImpl).shutdown();
+            if (!shutdown.join(1, TimeUnit.SECONDS).isSuccess()) {
+                logger.log(Level.WARNING, "Failure to shutdown OTel SDK");
+            }
+        }
+        GlobalOpenTelemetry.resetForTest();
+        GlobalEventLoggerProvider.resetForTest();
+    }
+
+    @Override
+    public TracerProvider getTracerProvider() {
+        return traceProviderImpl;
+    }
+
+    @Override
+    public Tracer getTracer(String instrumentationScopeName) {
+        return traceProviderImpl.get(instrumentationScopeName);
+    }
+
+    @Override
+    public Tracer getTracer(String instrumentationScopeName, String instrumentationScopeVersion) {
+        return traceProviderImpl.get(instrumentationScopeName, instrumentationScopeVersion);
+    }
+
+    @Override
+    public TracerBuilder tracerBuilder(String instrumentationScopeName) {
+        return traceProviderImpl.tracerBuilder(instrumentationScopeName);
+    }
+
+    @Override
+    public MeterProvider getMeterProvider() {
+        return meterProviderImpl;
+    }
+
+    @Override
+    public EventLoggerProvider getEventLoggerProvider() {
+        return eventLoggerProviderImpl;
+    }
+
+    @Override
+    public EventLoggerBuilder eventLoggerBuilder(String instrumentationScopeName) {
+        return eventLoggerProviderImpl.eventLoggerBuilder(instrumentationScopeName);
+    }
+
+    @Override
+    public Meter getMeter(String instrumentationScopeName) {
+        return meterProviderImpl.get(instrumentationScopeName);
+    }
+
+    @Override
+    public MeterBuilder meterBuilder(String instrumentationScopeName) {
+        return meterProviderImpl.meterBuilder(instrumentationScopeName);
+    }
+
+    @Deprecated
+    @Override
+    public OpenTelemetry getImplementation() {
+        return openTelemetryImpl;
+    }
+
+    @Override
+    @NonNull
+    public Resource getResource() {
+        return resource;
+    }
+
+    @Override
+    @NonNull
+    public ConfigProperties getConfig() {
+        return config;
+    }
+
+    @Override
+    public LoggerProvider getLogsBridge() {
+        return loggerProviderImpl;
+    }
+
+    @Override
+    public ContextPropagators getPropagators() {
+        return openTelemetryImpl.getPropagators();
+    }
+
+    @OverridingMethodsMustInvokeSuper
+    protected void postOpenTelemetrySdkConfiguration() {
+        ExtensionList.lookup(OpenTelemetryLifecycleListener.class).stream().sorted().forEach(openTelemetryLifecycleListener -> {
+            logger.log(Level.FINE, () -> "Notify " + openTelemetryLifecycleListener + " after OpenTelemetry configuration");
+            openTelemetryLifecycleListener.afterConfiguration(this.config);
+        });
+    }
+}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableTracerProvider.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableTracerProvider.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.api;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerBuilder;
+import io.opentelemetry.api.trace.TracerProvider;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * <p>
+ * A {@link TracerProvider} that allows to reconfigure the {@link Tracer}s.
+ * </p>
+ * <p>
+ * We need reconfigurability because Jenkins supports changing the configuration of the OpenTelemetry params at runtime.
+ * All instantiated tracers are reconfigured when the configuration changes, when
+ * {@link ReconfigurableTracerProvider#setDelegate(TracerProvider)} is invoked.
+ * </p>
+ */
+class ReconfigurableTracerProvider implements TracerProvider {
+
+    private TracerProvider delegate;
+
+    private final ConcurrentMap<InstrumentationScope, ReconfigurableTracer> tracers = new ConcurrentHashMap<>();
+
+    public ReconfigurableTracerProvider() {
+        this(TracerProvider.noop());
+    }
+
+    public ReconfigurableTracerProvider(TracerProvider delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public synchronized Tracer get(String instrumentationScopeName) {
+        return tracers.computeIfAbsent(
+            new InstrumentationScope(instrumentationScopeName),
+            instrumentationScope -> new ReconfigurableTracer(delegate.get(instrumentationScope.instrumentationScopeName)));
+    }
+
+    public synchronized void setDelegate(TracerProvider delegate) {
+        this.delegate = delegate;
+        tracers.forEach((instrumentationScope, reconfigurableTracer) -> {
+            TracerBuilder tracerBuilder = delegate.tracerBuilder(instrumentationScope.instrumentationScopeName);
+            Optional.ofNullable(instrumentationScope.instrumentationScopeVersion).ifPresent(tracerBuilder::setInstrumentationVersion);
+            Optional.ofNullable(instrumentationScope.schemaUrl).ifPresent(tracerBuilder::setSchemaUrl);
+            reconfigurableTracer.setDelegate(tracerBuilder.build());
+        });
+    }
+
+    @Override
+    public Tracer get(String instrumentationScopeName, String instrumentationScopeVersion) {
+        return tracers.computeIfAbsent(
+            new InstrumentationScope(instrumentationScopeName, null, instrumentationScopeVersion),
+            instrumentationScope -> new ReconfigurableTracer(delegate.get(instrumentationScopeName, instrumentationScopeVersion)));
+    }
+
+    @Override
+    public TracerBuilder tracerBuilder(String instrumentationScopeName) {
+        return new ReconfigurableTracerBuilder(delegate.tracerBuilder(instrumentationScopeName), instrumentationScopeName);
+    }
+
+    public synchronized TracerProvider getDelegate() {
+        return delegate;
+    }
+
+    @VisibleForTesting
+    protected class ReconfigurableTracerBuilder implements TracerBuilder {
+        TracerBuilder delegate;
+        String instrumentationScopeName;
+        String schemaUrl;
+        String instrumentationScopeVersion;
+
+        public ReconfigurableTracerBuilder(TracerBuilder delegate, String instrumentationScopeName) {
+            this.delegate = Objects.requireNonNull(delegate);
+            this.instrumentationScopeName = Objects.requireNonNull(instrumentationScopeName);
+        }
+
+        @Override
+        public TracerBuilder setSchemaUrl(String schemaUrl) {
+            delegate.setSchemaUrl(schemaUrl);
+            this.schemaUrl = schemaUrl;
+            return this;
+        }
+
+        @Override
+        public TracerBuilder setInstrumentationVersion(String instrumentationScopeVersion) {
+            delegate.setInstrumentationVersion(instrumentationScopeVersion);
+            this.instrumentationScopeVersion = instrumentationScopeVersion;
+            return this;
+        }
+
+        @Override
+        public Tracer build() {
+            InstrumentationScope instrumentationScope = new InstrumentationScope(instrumentationScopeName, schemaUrl, instrumentationScopeVersion);
+            return tracers.computeIfAbsent(instrumentationScope, k -> new ReconfigurableTracer(delegate.build()));
+        }
+    }
+
+    @VisibleForTesting
+    protected static class ReconfigurableTracer implements Tracer {
+        Tracer delegate;
+
+        public ReconfigurableTracer(Tracer delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public synchronized SpanBuilder spanBuilder(@Nonnull String spanName) {
+            return delegate.spanBuilder(spanName);
+        }
+
+        public synchronized void setDelegate(Tracer delegate) {
+            this.delegate = delegate;
+        }
+
+        public synchronized Tracer getDelegate() {
+            return delegate;
+        }
+    }
+
+}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/package-info.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+@ParametersAreNonnullByDefault
+package io.jenkins.plugins.opentelemetry.api;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/util/ConfigPropertiesUtils.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/util/ConfigPropertiesUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.api.util;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.ServiceAttributes;
+import io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class ConfigPropertiesUtils {
+
+    /**
+     * Helper because there is no public implementation of the "i.o.s.a.s.ConfigProperties" interface.
+     */
+    public static ConfigProperties emptyConfig(){
+        return DefaultConfigProperties.createFromMap(Collections.emptyMap());
+    }
+
+    public static String prettyPrintOtelSdkConfig(ConfigProperties configProperties, Resource resource) {
+        return "SDK [" +
+                "config: " + prettyPrintConfiguration(configProperties) + ", "+
+                "resource: " + prettyPrintResource(resource) +
+                "]";
+    }
+    public static String prettyPrintConfiguration(ConfigProperties config) {
+        Map<String, String> message = new LinkedHashMap<>();
+        for (String attributeName : noteworthyConfigurationPropertyNames) {
+            final String attributeValue = config.getString(attributeName);
+            if (attributeValue != null) {
+                message.put(attributeName, attributeValue);
+            }
+        }
+        return message.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue()).collect(Collectors.joining(", "));
+    }
+    public static String prettyPrintResource(@Nullable Resource resource) {
+        if (resource == null) {
+            return "#null#";
+        }
+        Map<String, String> message = new LinkedHashMap<>();
+        for (AttributeKey attributeKey : noteworthyResourceAttributeKeys) {
+            Object attributeValue = resource.getAttribute(attributeKey);
+            if (attributeValue != null) {
+                message.put(attributeKey.getKey(), Objects.toString(attributeValue, "#null#"));
+            }
+        }
+        return message.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue()).collect(Collectors.joining(", "));
+    }
+    private final static List<String> noteworthyConfigurationPropertyNames = Arrays.asList(
+            "otel.resource.attributes", "otel.service.name",
+            "otel.traces.exporter", "otel.metrics.exporter", "otel.logs.exporter",
+            "otel.exporter.otlp.endpoint"  , "otel.exporter.otlp.traces.endpoint", "otel.exporter.otlp.metrics.endpoint",
+            "otel.exporter.jaeger.endpoint", "otel.exporter.prometheus.port");
+
+    private final static List<AttributeKey> noteworthyResourceAttributeKeys = Arrays.asList(
+            ServiceAttributes.SERVICE_NAME, ServiceIncubatingAttributes.SERVICE_NAMESPACE, ServiceAttributes.SERVICE_VERSION
+    ) ;
+
+}

--- a/src/test/java/io/jenkins/plugins/opentelemetry/ClasspathTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/ClasspathTest.java
@@ -1,4 +1,4 @@
-package io.jenkins.plugins.opentelemetryapi;
+package io.jenkins.plugins.opentelemetry;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.*;

--- a/src/test/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableEventLoggerProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableEventLoggerProviderTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.api;
+
+import io.opentelemetry.api.incubator.events.EventBuilder;
+import io.opentelemetry.api.incubator.events.EventLogger;
+import io.opentelemetry.api.incubator.events.EventLoggerBuilder;
+import io.opentelemetry.api.incubator.events.EventLoggerProvider;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
+
+public class ReconfigurableEventLoggerProviderTest {
+
+    @org.junit.Test
+    public void testEventLoggerBuilder() {
+        ReconfigurableEventLoggerProvider eventLoggerProvider = new ReconfigurableEventLoggerProvider();
+
+        EventLoggerProviderMock eventLoggerProviderImpl_1 = new EventLoggerProviderMock();
+        eventLoggerProvider.setDelegate(eventLoggerProviderImpl_1);
+
+        ReconfigurableEventLoggerProvider.ReconfigurableEventLogger authenticationEventLogger = (ReconfigurableEventLoggerProvider.ReconfigurableEventLogger) eventLoggerProvider
+            .eventLoggerBuilder("io.jenkins.authentication")
+            .setInstrumentationVersion("1.0.0")
+            .build();
+
+        EventLoggerMock authenticationEventLoggerImpl = (EventLoggerMock) authenticationEventLogger.delegateEventLogger;
+        assertEquals("io.jenkins.authentication", authenticationEventLoggerImpl.instrumentationScopeName);
+        assertNull(authenticationEventLoggerImpl.schemaUrl);
+        assertEquals("1.0.0", authenticationEventLoggerImpl.instrumentationVersion);
+        assertEquals(eventLoggerProviderImpl_1.id, authenticationEventLoggerImpl.eventLoggerProviderId);
+
+
+        ReconfigurableEventLoggerProvider.ReconfigurableEventLogger buildEventLogger = (ReconfigurableEventLoggerProvider.ReconfigurableEventLogger) eventLoggerProvider
+            .eventLoggerBuilder("io.jenkins.build")
+            .setSchemaUrl("https://jenkins.io/build")
+            .build();
+        EventLoggerMock buildEventLoggerImpl = (EventLoggerMock) buildEventLogger.delegateEventLogger;
+        assertEquals("io.jenkins.build", buildEventLoggerImpl.instrumentationScopeName);
+        assertEquals("https://jenkins.io/build", buildEventLoggerImpl.schemaUrl);
+        assertNull(buildEventLoggerImpl.instrumentationVersion);
+        assertEquals(eventLoggerProviderImpl_1.id, buildEventLoggerImpl.eventLoggerProviderId);
+
+        ReconfigurableEventLoggerProvider.ReconfigurableEventLogger buildEventLoggerShouldBeTheSameInstance = (ReconfigurableEventLoggerProvider.ReconfigurableEventLogger) eventLoggerProvider
+            .eventLoggerBuilder("io.jenkins.build")
+            .setSchemaUrl("https://jenkins.io/build")
+            .build();
+
+        assertEquals(buildEventLogger, buildEventLoggerShouldBeTheSameInstance);
+
+        EventLoggerProviderMock eventLoggerProviderImpl_2 = new EventLoggerProviderMock();
+        assertNotEquals(eventLoggerProviderImpl_1.id, eventLoggerProviderImpl_2.id);
+
+        // CHANGE THE IMPLEMENTATION OF THE EVENT LOGGER PROVIDER
+        eventLoggerProvider.setDelegate(eventLoggerProviderImpl_2);
+
+        // VERIFY THE DELEGATE IMPL HAS CHANGED WHILE THE PARAMS REMAINS UNCHANGED
+        EventLoggerMock authenticationEventLoggerImpl_2 = (EventLoggerMock) authenticationEventLogger.delegateEventLogger;
+        assertEquals("io.jenkins.authentication", authenticationEventLoggerImpl_2.instrumentationScopeName);
+        assertNull(authenticationEventLoggerImpl_2.schemaUrl);
+        assertEquals("1.0.0", authenticationEventLoggerImpl_2.instrumentationVersion);
+        assertEquals(eventLoggerProviderImpl_2.id, authenticationEventLoggerImpl_2.eventLoggerProviderId);
+
+        EventLoggerMock buildEventLoggerImpl_2 = (EventLoggerMock) buildEventLogger.delegateEventLogger;
+
+        assertEquals("io.jenkins.build", buildEventLoggerImpl_2.instrumentationScopeName);
+        assertEquals("https://jenkins.io/build", buildEventLoggerImpl_2.schemaUrl);
+        assertNull(buildEventLoggerImpl_2.instrumentationVersion);
+        assertEquals(eventLoggerProviderImpl_2.id, buildEventLoggerImpl_2.eventLoggerProviderId);
+    }
+
+
+    static class EventLoggerProviderMock implements EventLoggerProvider {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+        final String id;
+
+        public EventLoggerProviderMock() {
+            this.id = "EventLoggerProviderMock-" + ID_SOURCE.incrementAndGet();
+        }
+
+        @Override
+        public EventLoggerBuilder eventLoggerBuilder(String instrumentationScopeName) {
+            return new EventLoggerBuilderMock(instrumentationScopeName, id);
+        }
+
+        @Override
+        public EventLogger get(String instrumentationScopeName) {
+            return new EventLoggerMock(instrumentationScopeName, id);
+        }
+    }
+
+    static class EventLoggerMock implements EventLogger {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+
+        final String instrumentationScopeName;
+        final String eventLoggerProviderId;
+        final String id;
+
+        final String schemaUrl;
+        final String instrumentationVersion;
+
+        public EventLoggerMock(String instrumentationScopeName, String eventLoggerProviderId) {
+            this(instrumentationScopeName, eventLoggerProviderId, null, null);
+        }
+        public EventLoggerMock(String instrumentationScopeName, String eventLoggerProviderId, @Nullable String schemaUrl, @Nullable String instrumentationVersion) {
+            this.id = "EventLoggerMock-" + ID_SOURCE.incrementAndGet();
+            this.instrumentationScopeName = instrumentationScopeName;
+            this.eventLoggerProviderId = eventLoggerProviderId;
+            this.schemaUrl = schemaUrl;
+            this.instrumentationVersion = instrumentationVersion;
+        }
+
+        @Override
+        public EventBuilder builder(String eventName) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    static class EventLoggerBuilderMock implements EventLoggerBuilder {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+        final String id;
+        final String instrumentationScopeName;
+        final String eventLoggerProviderId;
+        String schemaUrl;
+        String instrumentationVersion;
+
+
+        public EventLoggerBuilderMock(String instrumentationScopeName, String eventLoggerProviderId) {
+            this.id = "EventLoggerBuilderMock-" + ID_SOURCE.incrementAndGet();
+            this.instrumentationScopeName = instrumentationScopeName;
+            this.eventLoggerProviderId = eventLoggerProviderId;
+        }
+
+        @Override
+        public EventLoggerBuilder setSchemaUrl(String schemaUrl) {
+            this.schemaUrl = schemaUrl;
+            return this;
+        }
+
+        @Override
+        public EventLoggerBuilder setInstrumentationVersion(String instrumentationVersion) {
+            this.instrumentationVersion = instrumentationVersion;
+            return this;
+        }
+
+        @Override
+        public EventLogger build() {
+            return new EventLoggerMock(instrumentationScopeName, eventLoggerProviderId, schemaUrl, instrumentationVersion);
+        }
+    }
+}

--- a/src/test/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableLoggerProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableLoggerProviderTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.api;
+
+
+import io.opentelemetry.api.logs.LogRecordBuilder;
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.api.logs.LoggerBuilder;
+import io.opentelemetry.api.logs.LoggerProvider;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
+
+public class ReconfigurableLoggerProviderTest {
+
+    @org.junit.Test
+    public void testLoggerBuilder() {
+        ReconfigurableLoggerProvider loggerProvider = new ReconfigurableLoggerProvider();
+
+        LoggerProviderMock loggerProviderImpl_1 = new LoggerProviderMock();
+        loggerProvider.setDelegate(loggerProviderImpl_1);
+
+        ReconfigurableLoggerProvider.ReconfigurableLogger authenticationLogger = (ReconfigurableLoggerProvider.ReconfigurableLogger) loggerProvider
+            .loggerBuilder("io.jenkins.authentication")
+            .setInstrumentationVersion("1.0.0")
+            .build();
+
+        LoggerMock authenticationLoggerImpl = (LoggerMock) authenticationLogger.delegate;
+        assertEquals("io.jenkins.authentication", authenticationLoggerImpl.instrumentationScopeName);
+        assertNull(authenticationLoggerImpl.schemaUrl);
+        assertEquals("1.0.0", authenticationLoggerImpl.instrumentationVersion);
+        assertEquals(loggerProviderImpl_1.id, authenticationLoggerImpl.loggerProviderId);
+
+
+        ReconfigurableLoggerProvider.ReconfigurableLogger buildLogger = (ReconfigurableLoggerProvider.ReconfigurableLogger) loggerProvider
+            .loggerBuilder("io.jenkins.build")
+            .setSchemaUrl("https://jenkins.io/build")
+            .build();
+        LoggerMock buildLoggerImpl = (LoggerMock) buildLogger.delegate;
+        assertEquals("io.jenkins.build", buildLoggerImpl.instrumentationScopeName);
+        assertEquals("https://jenkins.io/build", buildLoggerImpl.schemaUrl);
+        assertNull(buildLoggerImpl.instrumentationVersion);
+        assertEquals(loggerProviderImpl_1.id, buildLoggerImpl.loggerProviderId);
+
+        ReconfigurableLoggerProvider.ReconfigurableLogger buildLoggerShouldBeTheSameInstance = (ReconfigurableLoggerProvider.ReconfigurableLogger) loggerProvider
+            .loggerBuilder("io.jenkins.build")
+            .setSchemaUrl("https://jenkins.io/build")
+            .build();
+
+        assertEquals(buildLogger, buildLoggerShouldBeTheSameInstance);
+
+        LoggerProviderMock loggerProviderImpl_2 = new LoggerProviderMock();
+        assertNotEquals(loggerProviderImpl_1.id, loggerProviderImpl_2.id);
+
+        // CHANGE THE IMPLEMENTATION OF THE EVENT LOGGER PROVIDER
+        loggerProvider.setDelegate(loggerProviderImpl_2);
+
+        // VERIFY THE DELEGATE IMPL HAS CHANGED WHILE THE PARAMS REMAINS UNCHANGED
+        LoggerMock authenticationLoggerImpl_2 = (LoggerMock) authenticationLogger.delegate;
+        assertEquals("io.jenkins.authentication", authenticationLoggerImpl_2.instrumentationScopeName);
+        assertNull(authenticationLoggerImpl_2.schemaUrl);
+        assertEquals("1.0.0", authenticationLoggerImpl_2.instrumentationVersion);
+        assertEquals(loggerProviderImpl_2.id, authenticationLoggerImpl_2.loggerProviderId);
+
+        LoggerMock buildLoggerImpl_2 = (LoggerMock) buildLogger.delegate;
+
+        assertEquals("io.jenkins.build", buildLoggerImpl_2.instrumentationScopeName);
+        assertEquals("https://jenkins.io/build", buildLoggerImpl_2.schemaUrl);
+        assertNull(buildLoggerImpl_2.instrumentationVersion);
+        assertEquals(loggerProviderImpl_2.id, buildLoggerImpl_2.loggerProviderId);
+    }
+
+
+    static class LoggerProviderMock implements LoggerProvider {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+        final String id;
+
+        public LoggerProviderMock() {
+            this.id = "LoggerProviderMock-" + ID_SOURCE.incrementAndGet();
+        }
+
+        @Override
+        public LoggerBuilder loggerBuilder(String instrumentationScopeName) {
+            return new LoggerBuilderMock(instrumentationScopeName, id);
+        }
+
+        @Override
+        public Logger get(String instrumentationScopeName) {
+            return new LoggerMock(instrumentationScopeName, id);
+        }
+    }
+
+    static class LoggerMock implements Logger {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+
+        final String instrumentationScopeName;
+        final String loggerProviderId;
+        final String id;
+
+        final String schemaUrl;
+        final String instrumentationVersion;
+
+        public LoggerMock(String instrumentationScopeName, String loggerProviderId) {
+            this(instrumentationScopeName, loggerProviderId, null, null);
+        }
+        public LoggerMock(String instrumentationScopeName, String loggerProviderId, @Nullable String schemaUrl, @Nullable String instrumentationVersion) {
+            this.id = "LoggerMock-" + ID_SOURCE.incrementAndGet();
+            this.instrumentationScopeName = instrumentationScopeName;
+            this.loggerProviderId = loggerProviderId;
+            this.schemaUrl = schemaUrl;
+            this.instrumentationVersion = instrumentationVersion;
+        }
+
+        @Override
+        public LogRecordBuilder logRecordBuilder() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    static class LoggerBuilderMock implements LoggerBuilder {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+        final String id;
+        final String instrumentationScopeName;
+        final String loggerProviderId;
+        String schemaUrl;
+        String instrumentationVersion;
+
+
+        public LoggerBuilderMock(String instrumentationScopeName, String loggerProviderId) {
+            this.id = "LoggerBuilderMock-" + ID_SOURCE.incrementAndGet();
+            this.instrumentationScopeName = instrumentationScopeName;
+            this.loggerProviderId = loggerProviderId;
+        }
+
+        @Override
+        public LoggerBuilder setSchemaUrl(String schemaUrl) {
+            this.schemaUrl = schemaUrl;
+            return this;
+        }
+
+        @Override
+        public LoggerBuilder setInstrumentationVersion(String instrumentationVersion) {
+            this.instrumentationVersion = instrumentationVersion;
+            return this;
+        }
+
+        @Override
+        public Logger build() {
+            return new LoggerMock(instrumentationScopeName, loggerProviderId, schemaUrl, instrumentationVersion);
+        }
+    }
+}

--- a/src/test/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableMeterProviderITTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableMeterProviderITTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.api;
+
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongUpDownCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.exporter.logging.LoggingSpanExporter;
+import io.opentelemetry.instrumentation.runtimemetrics.java8.Classes;
+import io.opentelemetry.instrumentation.runtimemetrics.java8.Cpu;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.logs.SdkLoggerProvider;
+import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
+import io.opentelemetry.sdk.logs.internal.SdkEventLoggerProvider;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/LibraryTestRunner.java#L87
+ */
+public class ReconfigurableMeterProviderITTest {
+
+
+    @Test
+    public void testPlainOpenTelemetrySdk() {
+        try (OpenTelemetryTest openTelemetryTest = newOpenTelemetryTest()) {
+            InMemoryMetricReader metricReader = openTelemetryTest.metricReader;
+            MeterProvider meterProvider = openTelemetryTest.openTelemetrySdk.getMeterProvider();
+            Meter meter = meterProvider.meterBuilder("test-meter").build();
+
+            LongCounter longCounter = meter.counterBuilder("test.long.counter").build();
+            longCounter.add(1);
+            assertMetricExist("test.long.counter", metricReader);
+
+            ObservableLongMeasurement testLongCounterObserver = meter.counterBuilder("test.long.counter.observer").buildObserver();
+            meter.batchCallback(() -> testLongCounterObserver.record(1), testLongCounterObserver);
+            assertMetricExist("test.long.counter.observer", metricReader);
+
+            meter.counterBuilder("test.long.counter.callback").buildWithCallback(observableLongMeasurement -> observableLongMeasurement.record(1));
+            assertMetricExist("test.long.counter.callback", metricReader);
+
+            // UP DOWN COUNTER
+            LongUpDownCounter longUpDownCounter = meter.upDownCounterBuilder("test.long.up.down.counter").build();
+            longUpDownCounter.add(1);
+            assertMetricExist("test.long.up.down.counter", metricReader);
+
+            Classes.registerObservers(openTelemetryTest.openTelemetrySdk);
+            assertMetricExist("jvm.class.loaded", metricReader);
+            assertMetricExist("jvm.class.count", metricReader);
+            assertMetricExist("jvm.class.unloaded", metricReader);
+
+        }
+    }
+
+    @Test
+    public void testReconfigurableOpenTelemetrySdk() {
+        try (ReconfigurableOpenTelemetry reconfigurableOpenTelemetry = new ReconfigurableOpenTelemetry()) {
+            try (OpenTelemetryTest openTelemetryTest = newOpenTelemetryTest()) {
+                reconfigurableOpenTelemetry.setOpenTelemetryImpl(openTelemetryTest.openTelemetrySdk);
+
+                InMemoryMetricReader metricReader = openTelemetryTest.metricReader;
+
+                MeterProvider meterProvider = reconfigurableOpenTelemetry.getMeterProvider();
+                Meter meter = meterProvider.meterBuilder("test-meter").build();
+
+                LongCounter longCounter = meter.counterBuilder("test.long.counter").build();
+                longCounter.add(1);
+                assertMetricExist("test.long.counter", metricReader);
+
+                ObservableLongMeasurement testLongCounterObserver = meter.counterBuilder("test.long.counter.observer").buildObserver();
+                meter.batchCallback(() -> testLongCounterObserver.record(1), testLongCounterObserver);
+
+                assertMetricExist("test.long.counter.observer", metricReader);
+
+                Classes.registerObservers(openTelemetryTest.openTelemetrySdk);
+                assertMetricExist("jvm.class.loaded", metricReader);
+                assertMetricExist("jvm.class.count", metricReader);
+                assertMetricExist("jvm.class.unloaded", metricReader);
+
+                Cpu.registerObservers(reconfigurableOpenTelemetry);
+                assertMetricExist("jvm.cpu.count", metricReader);
+                assertMetricExist("jvm.cpu.time", metricReader);
+                assertMetricExist("jvm.cpu.recent_utilization", metricReader);
+            }
+        }
+    }
+
+    @Test
+    public void testReconfigurableOpenTelemetrySdkAfterNopInitialization() {
+        try (ReconfigurableOpenTelemetry reconfigurableOpenTelemetry = new ReconfigurableOpenTelemetry()) {
+
+            MeterProvider meterProvider = reconfigurableOpenTelemetry.getMeterProvider();
+            Meter meter = meterProvider.meterBuilder("test-meter").build();
+
+            // LONG COUNTER
+            LongCounter longCounter = meter.counterBuilder("test.long.counter").build();
+            longCounter.add(1);
+
+            ObservableLongMeasurement testLongCounterObserverMeasurement = meter.counterBuilder("test.long.counter.observer").buildObserver();
+            Runnable testLongCounterObserverCallback = () -> testLongCounterObserverMeasurement.record(1);
+            meter.batchCallback(testLongCounterObserverCallback, testLongCounterObserverMeasurement);
+
+            meter.counterBuilder("test.long.counter.callback").buildWithCallback(observableLongMeasurement -> observableLongMeasurement.record(1));
+
+            // UP DOWN COUNTER
+            LongUpDownCounter longUpDownCounter = meter.upDownCounterBuilder("test.long.up.down.counter").build();
+            longUpDownCounter.add(1);
+            // long up down counter callback
+            meter.upDownCounterBuilder("test.long.up.down.counter.callback").buildWithCallback(observableLongMeasurement -> observableLongMeasurement.record(1));
+            // long up down counter observer
+            ObservableLongMeasurement testLongUpDownCounterObserverMeasurement = meter.upDownCounterBuilder("test.long.up.down.counter.observer").buildObserver();
+            meter.batchCallback(() -> testLongUpDownCounterObserverMeasurement.record(1), testLongUpDownCounterObserverMeasurement);
+
+            // JVM metrics
+            Classes.registerObservers(reconfigurableOpenTelemetry);
+            Cpu.registerObservers(reconfigurableOpenTelemetry);
+            // GarbageCollector.registerObservers(reconfigurableOpenTelemetry); jvm.gc.duration is an histogram and not supported yet
+
+            try (OpenTelemetryTest openTelemetryTest = newOpenTelemetryTest()) {
+
+                reconfigurableOpenTelemetry.setOpenTelemetryImpl(openTelemetryTest.openTelemetrySdk);
+                InMemoryMetricReader metricReader = openTelemetryTest.metricReader;
+
+                // LONG COUNTER
+                assertMetricDoesntExist("test.long.counter", metricReader);
+                longCounter.add(2);
+                assertMetricExist("test.long.counter", metricReader);
+
+                // LONG COUNTER OBSERVER
+                // "test.long.counter.observer" was registered before the reconfiguration and should continue to exist
+                assertMetricExist("test.long.counter.observer", metricReader);
+
+                // LONG COUNTER CALLBACK
+                // "test.long.counter.callback" was registered before the reconfiguration and should continue to exist
+                assertMetricExist("test.long.counter.callback", metricReader);
+
+                // LONG UP DOWN COUNTER
+                longUpDownCounter.add(2);
+                assertMetricExist("test.long.up.down.counter", metricReader);
+
+                // LONG UP DOWN COUNTER CALLBACK
+                // "test.long.up.down.counter.callback" was registered before the reconfiguration and should continue to exist
+                assertMetricExist("test.long.up.down.counter.callback", metricReader);
+
+                // LONG UP DOWN COUNTER OBSERVER
+                // "test.long.up.down.counter.observer" was registered before the reconfiguration and should continue to exist
+                assertMetricExist("test.long.up.down.counter.observer", metricReader);
+
+                // JVM
+                assertMetricExist("jvm.class.loaded", metricReader);
+                assertMetricExist("jvm.class.count", metricReader);
+                assertMetricExist("jvm.class.unloaded", metricReader);
+
+                assertMetricExist("jvm.cpu.count", metricReader);
+                assertMetricExist("jvm.cpu.time", metricReader);
+                assertMetricExist("jvm.cpu.recent_utilization", metricReader);
+            }
+        }
+    }
+
+
+    private static void assertMetricExist(String metricName, InMemoryMetricReader metricReader) {
+        Assert.assertTrue("Metric '" + metricName + "' was not exported", metricReader.collectAllMetrics().stream().anyMatch(metricData -> metricName.equals(metricData.getName())));
+    }
+
+    private static void assertMetricDoesntExist(String metricName, InMemoryMetricReader metricReader) {
+        Assert.assertTrue("Metric '" + metricName + "' should not exist", metricReader.collectAllMetrics().stream().noneMatch(metricData -> metricName.equals(metricData.getName())));
+    }
+
+    OpenTelemetryTest newOpenTelemetryTest() {
+
+        InMemoryLogRecordExporter testLogRecordExporter = InMemoryLogRecordExporter.create();
+
+        InMemoryMetricReader metricReader = InMemoryMetricReader.create();
+
+        OpenTelemetrySdk openTelemetryImpl =
+            OpenTelemetrySdk.builder()
+                .setTracerProvider(
+                    SdkTracerProvider.builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
+                        .addSpanProcessor(SimpleSpanProcessor.create(InMemorySpanExporter.create()))
+                        .build())
+                .setMeterProvider(SdkMeterProvider.builder().registerMetricReader(metricReader).build())
+                .setLoggerProvider(
+                    SdkLoggerProvider.builder()
+                        .addLogRecordProcessor(SimpleLogRecordProcessor.create(testLogRecordExporter))
+                        .build())
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                .build();
+
+        return new OpenTelemetryTest(openTelemetryImpl, metricReader);
+    }
+
+    static class OpenTelemetryTest implements AutoCloseable {
+        final OpenTelemetrySdk openTelemetrySdk;
+        final InMemoryMetricReader metricReader;
+
+        public OpenTelemetryTest(OpenTelemetrySdk openTelemetrySdk, InMemoryMetricReader metricReader) {
+            this.openTelemetrySdk = openTelemetrySdk;
+            this.metricReader = metricReader;
+        }
+
+        @Override
+        public void close() {
+            this.openTelemetrySdk.shutdown();
+        }
+    }
+}

--- a/src/test/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableMeterProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableMeterProviderTest.java
@@ -1,0 +1,835 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.api;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.incubator.metrics.ExtendedDoubleHistogramBuilder;
+import io.opentelemetry.api.incubator.metrics.ExtendedLongHistogramBuilder;
+import io.opentelemetry.api.metrics.BatchCallback;
+import io.opentelemetry.api.metrics.DoubleCounter;
+import io.opentelemetry.api.metrics.DoubleCounterBuilder;
+import io.opentelemetry.api.metrics.DoubleGauge;
+import io.opentelemetry.api.metrics.DoubleGaugeBuilder;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongCounterBuilder;
+import io.opentelemetry.api.metrics.LongGauge;
+import io.opentelemetry.api.metrics.LongGaugeBuilder;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.LongHistogramBuilder;
+import io.opentelemetry.api.metrics.LongUpDownCounterBuilder;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterBuilder;
+import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.metrics.ObservableDoubleCounter;
+import io.opentelemetry.api.metrics.ObservableDoubleGauge;
+import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
+import io.opentelemetry.api.metrics.ObservableLongCounter;
+import io.opentelemetry.api.metrics.ObservableLongGauge;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import io.opentelemetry.api.metrics.ObservableMeasurement;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfoBuilder;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.*;
+
+/*
+ * https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/LibraryTestRunner.java#L87
+ */
+
+public class ReconfigurableMeterProviderTest {
+
+    final static Random random = new Random();
+
+    @org.junit.Test
+    public void test() {
+        ReconfigurableMeterProvider meterProvider = new ReconfigurableMeterProvider();
+
+        MeterProviderMock meterProviderImpl_1 = new MeterProviderMock();
+        meterProvider.setDelegate(meterProviderImpl_1);
+
+        ReconfigurableMeterProvider.ReconfigurableMeter jenkinsMeter = (ReconfigurableMeterProvider.ReconfigurableMeter) meterProvider
+            .meterBuilder("io.jenkins")
+            .setInstrumentationVersion("1.0.0")
+            .build();
+
+        MeterMock jenkinsMeterImpl = (MeterMock) jenkinsMeter.delegate;
+        assertEquals("io.jenkins", jenkinsMeterImpl.instrumentationScopeInfo.getName());
+        assertNull(jenkinsMeterImpl.instrumentationScopeInfo.getSchemaUrl());
+        assertEquals("1.0.0", jenkinsMeterImpl.instrumentationScopeInfo.getVersion());
+        assertEquals(meterProviderImpl_1.id, jenkinsMeterImpl.meterProviderId);
+
+
+        ReconfigurableMeterProvider.ReconfigurableMeter myFrameworkMeter = (ReconfigurableMeterProvider.ReconfigurableMeter) meterProvider
+            .meterBuilder("io.myframework")
+            .setSchemaUrl("https://myframework.io/")
+            .build();
+        MeterMock myFrameworkMeterImpl = (MeterMock) myFrameworkMeter.delegate;
+        assertEquals("io.myframework", myFrameworkMeterImpl.instrumentationScopeInfo.getName());
+        assertEquals("https://myframework.io/", myFrameworkMeterImpl.instrumentationScopeInfo.getSchemaUrl());
+        assertNull(myFrameworkMeterImpl.instrumentationScopeInfo.getVersion());
+        assertEquals(meterProviderImpl_1.id, myFrameworkMeterImpl.meterProviderId);
+
+        ReconfigurableMeterProvider.ReconfigurableMeter myFrameworkMeterShouldBeTheSameInstance = (ReconfigurableMeterProvider.ReconfigurableMeter) meterProvider
+            .meterBuilder("io.myframework")
+            .setSchemaUrl("https://myframework.io/")
+            .build();
+
+        assertEquals(myFrameworkMeter, myFrameworkMeterShouldBeTheSameInstance);
+
+        // #### COUNTER ####
+
+        // Long Counter
+        ReconfigurableMeterProvider.ReconfigurableLongCounter jenkinsBuildCounter = (ReconfigurableMeterProvider.ReconfigurableLongCounter) jenkinsMeter.counterBuilder("jenkins.build.counter").build();
+        LongCounterMock jenkinsBuildCounterImpl = (LongCounterMock) jenkinsBuildCounter.getDelegate();
+        assertEquals(meterProviderImpl_1.id, jenkinsBuildCounterImpl.meterProviderId);
+
+        // Observable Long Counter
+        ReconfigurableMeterProvider.ReconfigurableObservableLongCounter observableLongCounter = (ReconfigurableMeterProvider.ReconfigurableObservableLongCounter) jenkinsMeter.counterBuilder("observable.long.counter").buildWithCallback(observableLongMeasurement -> observableLongMeasurement.record(random.nextInt(5)));
+        ObservableLongCounterMock observableLongCounterMock = (ObservableLongCounterMock) observableLongCounter.delegate;
+        assertEquals(meterProviderImpl_1.id, observableLongCounterMock.meterProviderId);
+
+        // Observable Long Measurement
+        ReconfigurableMeterProvider.ReconfigurableObservableLongMeasurement observableLongCounterMeasurement = (ReconfigurableMeterProvider.ReconfigurableObservableLongMeasurement) jenkinsMeter.counterBuilder("observable.long.counter.measurement").buildObserver();
+        ObservableLongMeasurementMock observableLongMeasurementMock = (ObservableLongMeasurementMock) observableLongCounterMeasurement.getDelegate();
+        assertEquals(meterProviderImpl_1.id, observableLongMeasurementMock.meterProviderId);
+
+        // Double Counter
+        ReconfigurableMeterProvider.ReconfigurableDoubleCounter jenkinsBuildDurationCounter = (ReconfigurableMeterProvider.ReconfigurableDoubleCounter) jenkinsMeter.counterBuilder("jenkins.build.duration.counter").ofDoubles().build();
+        DoubleCounterMock jenkinsBuildDurationCounterImpl = (DoubleCounterMock) jenkinsBuildDurationCounter.getDelegate();
+        assertEquals(meterProviderImpl_1.id, jenkinsBuildDurationCounterImpl.meterProviderId);
+
+        // Observable Double Counter
+        ReconfigurableMeterProvider.ReconfigurableObservableDoubleCounter observableDoubleCounter = (ReconfigurableMeterProvider.ReconfigurableObservableDoubleCounter) jenkinsMeter.counterBuilder("observable.double.counter").ofDoubles().buildWithCallback(observableDoubleMeasurement -> observableDoubleMeasurement.record(random.nextDouble()));
+        ObservableDoubleCounterMock observableDoubleCounterImpl = (ObservableDoubleCounterMock) observableDoubleCounter.getDelegate();
+        assertEquals(meterProviderImpl_1.id, observableDoubleCounterImpl.meterProviderId);
+
+        // Observable Double Measurement
+        ReconfigurableMeterProvider.ReconfigurableObservableDoubleMeasurement observableDoubleMeasurement = (ReconfigurableMeterProvider.ReconfigurableObservableDoubleMeasurement) jenkinsMeter.counterBuilder("observable.double.measurement").ofDoubles().buildObserver();
+        ObservableDoubleMeasurementMock observableDoubleMeasurementImpl = (ObservableDoubleMeasurementMock) observableDoubleMeasurement.getDelegate();
+        assertEquals(meterProviderImpl_1.id, observableDoubleMeasurementImpl.meterProviderId);
+
+        // #### GAUGE ####
+
+        // Double Gauge
+        ReconfigurableMeterProvider.ReconfigurableDoubleGauge memoryUsedGauge = (ReconfigurableMeterProvider.ReconfigurableDoubleGauge) jenkinsMeter.gaugeBuilder("memory.used").build();
+        DoubleGaugeMock memoryLongGaugeImpl = (DoubleGaugeMock) memoryUsedGauge.getDelegate();
+        assertEquals(meterProviderImpl_1.id, memoryLongGaugeImpl.meterProviderId);
+
+        // Observable Double Gauge
+        ReconfigurableMeterProvider.ReconfigurableObservableDoubleGauge temperatureGauge = (ReconfigurableMeterProvider.ReconfigurableObservableDoubleGauge) jenkinsMeter.gaugeBuilder("temperature").buildWithCallback(observableDoubleGaugeMeasurement -> observableDoubleGaugeMeasurement.record(random.nextDouble()));
+        ObservableDoubleGaugeMock temperatureGaugeImpl = (ObservableDoubleGaugeMock) temperatureGauge.delegate;
+        assertEquals(meterProviderImpl_1.id, temperatureGaugeImpl.meterProviderId);
+
+        // Observable Double Measurement
+        ReconfigurableMeterProvider.ReconfigurableObservableDoubleMeasurement pressureMeasurement = (ReconfigurableMeterProvider.ReconfigurableObservableDoubleMeasurement) jenkinsMeter.gaugeBuilder("pressure").buildObserver();
+        ObservableDoubleMeasurementMock pressureMeasurementImpl = (ObservableDoubleMeasurementMock) pressureMeasurement.getDelegate();
+        assertEquals(meterProviderImpl_1.id, pressureMeasurementImpl.meterProviderId);
+
+
+        // Long Gauge
+        ReconfigurableMeterProvider.ReconfigurableLongGauge longGauge = (ReconfigurableMeterProvider.ReconfigurableLongGauge) jenkinsMeter.gaugeBuilder("long.gauge").ofLongs().build();
+        LongGaugeMock longGaugeImpl = (LongGaugeMock) longGauge.getDelegate();
+        assertEquals(meterProviderImpl_1.id, longGaugeImpl.meterProviderId);
+
+        // Observable Long Gauge
+        ReconfigurableMeterProvider.ReconfigurableObservableLongGauge observableLongGauge = (ReconfigurableMeterProvider.ReconfigurableObservableLongGauge) jenkinsMeter.gaugeBuilder("observable.long.gauge").ofLongs().buildWithCallback(observableLongMeasurement -> observableLongMeasurement.record(random.nextInt(5)));
+        ObservableLongGaugeMock observableLongGaugeImpl = (ObservableLongGaugeMock) observableLongGauge.delegate;
+        assertEquals(meterProviderImpl_1.id, observableLongGaugeImpl.meterProviderId);
+
+        // Observable Long Measurement
+        ReconfigurableMeterProvider.ReconfigurableObservableLongMeasurement observableLongGaugeMeasurement = (ReconfigurableMeterProvider.ReconfigurableObservableLongMeasurement) jenkinsMeter.gaugeBuilder("observable.long.measurement").ofLongs().buildObserver();
+        ObservableLongMeasurementMock observableLongMeasurementImpl = (ObservableLongMeasurementMock) observableLongGaugeMeasurement.getDelegate();
+        assertEquals(meterProviderImpl_1.id, observableLongMeasurementImpl.meterProviderId);
+
+        // Double histogram
+        ReconfigurableMeterProvider.ReconfigurableDoubleHistogram doubleHistogram = (ReconfigurableMeterProvider.ReconfigurableDoubleHistogram) jenkinsMeter.histogramBuilder("double.histogram").build();
+        DoubleHistogramMock doubleHistogramImpl = (DoubleHistogramMock) doubleHistogram.getDelegate();
+        assertEquals(meterProviderImpl_1.id, doubleHistogramImpl.meterProviderId);
+
+        // Long histogram
+        ReconfigurableMeterProvider.ReconfigurableLongHistogram longHistogram = (ReconfigurableMeterProvider.ReconfigurableLongHistogram) jenkinsMeter.histogramBuilder("long.histogram").ofLongs().build();
+        LongHistogramMock longHistogramImpl = (LongHistogramMock) longHistogram.getDelegate();
+        assertEquals(meterProviderImpl_1.id, longHistogramImpl.meterProviderId);
+
+        // ############################################################################################################
+        // CHANGE THE IMPLEMENTATION OF THE EVENT METER PROVIDER
+        MeterProviderMock meterProviderImpl_2 = new MeterProviderMock();
+        assertNotEquals(meterProviderImpl_1.id, meterProviderImpl_2.id);
+
+        meterProvider.setDelegate(meterProviderImpl_2);
+
+        // VERIFY THE DELEGATE IMPL HAS CHANGED WHILE THE PARAMS REMAINS UNCHANGED
+        MeterMock jenkinsMeterImpl_2 = (MeterMock) jenkinsMeter.delegate;
+        assertEquals("io.jenkins", jenkinsMeterImpl_2.instrumentationScopeInfo.getName());
+        assertNull(jenkinsMeterImpl_2.instrumentationScopeInfo.getSchemaUrl());
+        assertEquals("1.0.0", jenkinsMeterImpl_2.instrumentationScopeInfo.getVersion());
+        assertEquals(meterProviderImpl_2.id, jenkinsMeterImpl_2.meterProviderId);
+
+        MeterMock myFrameworkMeterImpl_2 = (MeterMock) myFrameworkMeter.delegate;
+
+        assertEquals("io.myframework", myFrameworkMeterImpl_2.instrumentationScopeInfo.getName());
+        assertEquals("https://myframework.io/", myFrameworkMeterImpl_2.instrumentationScopeInfo.getSchemaUrl());
+        assertNull(myFrameworkMeterImpl_2.instrumentationScopeInfo.getVersion());
+        assertEquals(meterProviderImpl_2.id, myFrameworkMeterImpl_2.meterProviderId);
+
+        // #### COUNTER ####
+
+        // Long Counter
+        assertEquals(meterProviderImpl_2.id, ((LongCounterMock) jenkinsBuildCounter.getDelegate()).meterProviderId);
+        // Observable Long Counter
+        assertEquals(meterProviderImpl_2.id, ((ObservableLongCounterMock) observableLongCounter.delegate).meterProviderId);
+        // Observable Long Measurement
+        assertEquals(meterProviderImpl_2.id, ((ObservableLongMeasurementMock) observableLongCounterMeasurement.getDelegate()).meterProviderId);
+
+        // Double Counter
+        assertEquals(meterProviderImpl_2.id, ((DoubleCounterMock) jenkinsBuildDurationCounter.getDelegate()).meterProviderId);
+        // Observable Double Counter
+        assertEquals(meterProviderImpl_2.id, ((ObservableDoubleCounterMock) observableDoubleCounter.getDelegate()).meterProviderId);
+        // Observable Double Measurement
+        assertEquals(meterProviderImpl_2.id, ((ObservableDoubleMeasurementMock) observableDoubleMeasurement.getDelegate()).meterProviderId);
+
+        // GAUGE
+
+        // Double Gauge
+        assertEquals(meterProviderImpl_2.id, ((DoubleGaugeMock) memoryUsedGauge.getDelegate()).meterProviderId);
+        // Observable Double Gauge
+        assertEquals(meterProviderImpl_2.id, ((ObservableDoubleGaugeMock) temperatureGauge.delegate).meterProviderId);
+        // Observable Double Measurement
+        assertEquals(meterProviderImpl_2.id, ((ObservableDoubleMeasurementMock) pressureMeasurement.getDelegate()).meterProviderId);
+
+        // Long Gauge
+        assertEquals(meterProviderImpl_2.id, ((LongGaugeMock) longGauge.getDelegate()).meterProviderId);
+        // Observable Long Gauge
+        assertEquals(meterProviderImpl_2.id, ((ObservableLongGaugeMock) observableLongGauge.delegate).meterProviderId);
+        // Observable Long Measurement
+        assertEquals(meterProviderImpl_2.id, ((ObservableLongMeasurementMock) observableLongGaugeMeasurement.getDelegate()).meterProviderId);
+
+        // HISTOGRAM
+        // Double histogram
+        assertEquals(meterProviderImpl_2.id, ((DoubleHistogramMock) doubleHistogram.getDelegate()).meterProviderId);
+        // Long histogram
+        assertEquals(meterProviderImpl_2.id, ((LongHistogramMock) longHistogram.getDelegate()).meterProviderId);
+
+    }
+
+
+    static class MeterProviderMock implements MeterProvider {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+        final String id;
+
+        public MeterProviderMock() {
+            this.id = "MeterProviderMock-" + ID_SOURCE.incrementAndGet();
+        }
+
+        @Override
+        public MeterBuilder meterBuilder(String instrumentationScopeName) {
+            return new MeterBuilderMock(instrumentationScopeName, id);
+        }
+
+        @Override
+        public Meter get(String instrumentationScopeName) {
+            return new MeterMock(InstrumentationScopeInfo.create(instrumentationScopeName), id);
+        }
+    }
+
+    static class MeterMock implements Meter {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+
+        final InstrumentationScopeInfo instrumentationScopeInfo;
+        final String meterProviderId;
+        final String id;
+
+        public MeterMock(InstrumentationScopeInfo instrumentationScopeInfo, String meterProviderId) {
+            this.id = "MeterMock-" + ID_SOURCE.incrementAndGet();
+            this.instrumentationScopeInfo = instrumentationScopeInfo;
+            this.meterProviderId = meterProviderId;
+        }
+
+        @Override
+        public LongCounterBuilder counterBuilder(String name) {
+            return new LongCounterBuilderMock(id, meterProviderId);
+        }
+
+        @Override
+        public LongUpDownCounterBuilder upDownCounterBuilder(String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public DoubleHistogramBuilder histogramBuilder(String name) {
+            return new DoubleHistogramBuilderMock(id, meterProviderId);
+        }
+
+        @Override
+        public DoubleGaugeBuilder gaugeBuilder(String name) {
+            return new DoubleGaugeBuilderMock(id, meterProviderId);
+        }
+
+        @Override
+        public BatchCallback batchCallback(Runnable callback, ObservableMeasurement observableMeasurement, ObservableMeasurement... additionalMeasurements) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    static class MeterBuilderMock implements MeterBuilder {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+        final String id;
+        final InstrumentationScopeInfoBuilder instrumentationScopeInfoBuilder;
+        final String meterProviderId;
+
+
+
+        public MeterBuilderMock(String instrumentationScopeName, String meterProviderId) {
+            this.id = "MeterBuilderMock-" + ID_SOURCE.incrementAndGet();
+            this.instrumentationScopeInfoBuilder = InstrumentationScopeInfo.builder(instrumentationScopeName);
+            this.meterProviderId = meterProviderId;
+        }
+
+        @Override
+        public MeterBuilder setSchemaUrl(String schemaUrl) {
+            this.instrumentationScopeInfoBuilder.setSchemaUrl(schemaUrl);
+            return this;
+        }
+
+        @Override
+        public MeterBuilder setInstrumentationVersion(String instrumentationVersion) {
+            this.instrumentationScopeInfoBuilder.setVersion(instrumentationVersion);
+            return this;
+        }
+
+        @Override
+        public Meter build() {
+            return new MeterMock(instrumentationScopeInfoBuilder.build(), meterProviderId);
+        }
+    }
+
+    static class LongCounterBuilderMock implements LongCounterBuilder {
+        final String meterId;
+        final String meterProviderId;
+        String description;
+        String unit;
+
+        public LongCounterBuilderMock(String meterId, String meterProviderId) {
+            this.meterId = meterId;
+            this.meterProviderId = meterProviderId;
+        }
+
+        @Override
+        public LongCounterBuilder setDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        @Override
+        public LongCounterBuilder setUnit(String unit) {
+            this.unit = unit;
+            return this;
+        }
+
+        @Override
+        public DoubleCounterBuilder ofDoubles() {
+            DoubleCounterBuilderMock doubleCounterBuilderMock = new DoubleCounterBuilderMock(meterId, meterProviderId);
+            Optional.ofNullable(description).ifPresent(doubleCounterBuilderMock::setDescription);
+            Optional.ofNullable(unit).ifPresent(doubleCounterBuilderMock::setUnit);
+            return doubleCounterBuilderMock;
+        }
+
+        @Override
+        public ObservableLongCounter buildWithCallback(Consumer<ObservableLongMeasurement> callback) {
+            return new ObservableLongCounterMock(meterId, meterProviderId);
+        }
+
+        @Override
+        public ObservableLongMeasurement buildObserver() {
+            return new ObservableLongMeasurementMock(meterId, meterProviderId);
+        }
+
+        @Override
+        public LongCounter build() {
+            return new LongCounterMock(meterId, meterProviderId);
+        }
+    }
+
+    static class ObservableLongCounterMock implements ObservableLongCounter {
+        final String meterProviderId;
+        final String meterId;
+
+        public ObservableLongCounterMock(String meterId, String meterProviderId) {
+            this.meterId = meterId;
+            this.meterProviderId = meterProviderId;
+        }
+    }
+
+    static class DoubleCounterBuilderMock implements DoubleCounterBuilder {
+        final String meterId;
+        final String meterProviderId;
+        String description;
+        String unit;
+
+        public DoubleCounterBuilderMock(String meterId, String meterProviderId) {
+            this.meterId = meterId;
+            this.meterProviderId = meterProviderId;
+        }
+
+        @Override
+        public DoubleCounterBuilder setDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        @Override
+        public DoubleCounterBuilder setUnit(String unit) {
+            this.unit = unit;
+            return this;
+        }
+
+        @Override
+        public ObservableDoubleCounter buildWithCallback(Consumer<ObservableDoubleMeasurement> callback) {
+            return new ObservableDoubleCounterMock(meterId, meterProviderId);
+        }
+
+        @Override
+        public ObservableDoubleMeasurement buildObserver() {
+            return new ObservableDoubleMeasurementMock(meterId, meterProviderId);
+        }
+
+        @Override
+        public DoubleCounter build() {
+            return new DoubleCounterMock(meterId, meterProviderId);
+        }
+
+    }
+
+    static class ObservableDoubleCounterMock implements ObservableDoubleCounter {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+        final String meterProviderId;
+        final String meterId;
+        final String id;
+
+        public ObservableDoubleCounterMock(String meterId, String meterProviderId) {
+            this.id = "ObservableDoubleCounterMock-" + ID_SOURCE.incrementAndGet();
+            this.meterId = meterId;
+            this.meterProviderId = meterProviderId;
+        }
+
+        @Override
+        public void close() {
+            ObservableDoubleCounter.super.close();
+        }
+    }
+
+    static class DoubleCounterMock implements DoubleCounter {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+        final String meterProviderId;
+        final String meterId;
+        final String id;
+
+        public DoubleCounterMock(String meterId, String meterProviderId) {
+            this.id = "DoubleCounterMock-" + ID_SOURCE.incrementAndGet();
+            this.meterId = meterId;
+            this.meterProviderId = meterProviderId;
+        }
+
+        @Override
+        public void add(double value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void add(double value, Attributes attributes) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void add(double value, Attributes attributes, Context context) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    static class LongCounterMock implements LongCounter {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+        final String meterProviderId;
+        final String meterId;
+        final String id;
+
+        public LongCounterMock(String meterId, String meterProviderId) {
+            this.id = "LongCounterMock-" + ID_SOURCE.incrementAndGet();
+            this.meterId = meterId;
+            this.meterProviderId = meterProviderId;
+        }
+
+        @Override
+        public void add(long value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void add(long value, Attributes attributes) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void add(long value, Attributes attributes, Context context) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    static class LongGaugeMock implements LongGauge {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+        final String meterProviderId;
+        final String meterId;
+        final String id;
+
+        public LongGaugeMock(String meterId, String meterProviderId) {
+            this.id = "LongCounterMock-" + ID_SOURCE.incrementAndGet();
+            this.meterId = meterId;
+            this.meterProviderId = meterProviderId;
+        }
+
+        @Override
+        public void set(long value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void set(long value, Attributes attributes) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void set(long value, Attributes attributes, Context context) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class ObservableLongMeasurementMock implements ObservableLongMeasurement {
+        final String meterProviderId;
+        final String meterId;
+
+        public ObservableLongMeasurementMock(String meterId, String meterProviderId) {
+            this.meterId = meterId;
+            this.meterProviderId = meterProviderId;
+        }
+
+        @Override
+        public void record(long value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void record(long value, Attributes attributes) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class ObservableDoubleMeasurementMock implements ObservableDoubleMeasurement {
+        final String meterProviderId;
+        final String meterId;
+
+        public ObservableDoubleMeasurementMock(String meterId, String meterProviderId) {
+            this.meterId = meterId;
+            this.meterProviderId = meterProviderId;
+        }
+
+        @Override
+        public void record(double value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void record(double value, Attributes attributes) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    static class DoubleGaugeBuilderMock implements DoubleGaugeBuilder {
+        final String meterId;
+        final String meterProviderId;
+        String description;
+        String unit;
+
+        public DoubleGaugeBuilderMock(String meterId, String meterProviderId) {
+            this.meterId = meterId;
+            this.meterProviderId = meterProviderId;
+        }
+
+        @Override
+        public DoubleGaugeBuilder setDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        @Override
+        public DoubleGaugeBuilder setUnit(String unit) {
+            this.unit = unit;
+            return this;
+        }
+
+        @Override
+        public ObservableDoubleGauge buildWithCallback(Consumer<ObservableDoubleMeasurement> callback) {
+            return new ObservableDoubleGaugeMock(meterId, meterProviderId);
+        }
+
+        @Override
+        public ObservableDoubleMeasurement buildObserver() {
+            return new ObservableDoubleMeasurementMock(meterId, meterProviderId);
+        }
+
+        @Override
+        public DoubleGauge build() {
+            return new DoubleGaugeMock(meterId, meterProviderId);
+        }
+
+        @Override
+        public LongGaugeBuilder ofLongs() {
+            return new LongGaugeBuilderMock(meterId, meterProviderId);
+        }
+    }
+
+    static class LongGaugeBuilderMock implements LongGaugeBuilder {
+        final String meterId;
+        final String meterProviderId;
+        String description;
+        String unit;
+
+        public LongGaugeBuilderMock(String meterId, String meterProviderId) {
+            this.meterId = meterId;
+            this.meterProviderId = meterProviderId;
+        }
+
+        @Override
+        public LongGaugeBuilder setDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        @Override
+        public LongGaugeBuilder setUnit(String unit) {
+            this.unit = unit;
+            return this;
+        }
+
+        @Override
+        public ObservableLongGauge buildWithCallback(Consumer<ObservableLongMeasurement> callback) {
+            return new ObservableLongGaugeMock(meterId, meterProviderId);
+        }
+
+        @Override
+        public ObservableLongMeasurement buildObserver() {
+            return new ObservableLongMeasurementMock(meterId, meterProviderId);
+        }
+
+        @Override
+        public LongGauge build() {
+            return new LongGaugeMock(meterId, meterProviderId);
+        }
+    }
+
+    static class ObservableLongGaugeMock implements ObservableLongGauge {
+        final String meterProviderId;
+        final String meterId;
+
+        public ObservableLongGaugeMock(String meterId, String meterProviderId) {
+            this.meterId = meterId;
+            this.meterProviderId = meterProviderId;
+        }
+    }
+
+    static class ObservableDoubleGaugeMock implements ObservableDoubleGauge {
+        final String meterProviderId;
+        final String meterId;
+
+        public ObservableDoubleGaugeMock(String meterId, String meterProviderId) {
+            this.meterId = meterId;
+            this.meterProviderId = meterProviderId;
+        }
+    }
+
+    static class DoubleGaugeMock implements DoubleGauge {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+        final String meterProviderId;
+        final String meterId;
+        final String id;
+
+        public DoubleGaugeMock(String meterId, String meterProviderId) {
+            this.id = "DoubleGaugeMock-" + ID_SOURCE.incrementAndGet();
+            this.meterId = meterId;
+            this.meterProviderId = meterProviderId;
+        }
+
+        @Override
+        public void set(double value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void set(double value, Attributes attributes) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void set(double value, Attributes attributes, Context context) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    static class DoubleHistogramBuilderMock implements ExtendedDoubleHistogramBuilder {
+        final String meterId;
+        final String meterProviderId;
+        String description;
+        String unit;
+        List<AttributeKey<?>> attributes;
+        List<Double> bucketBoundaries;
+
+        public DoubleHistogramBuilderMock(String meterId, String meterProviderId) {
+            this.meterId = meterId;
+            this.meterProviderId = meterProviderId;
+        }
+
+        @Override
+        public DoubleHistogramBuilder setDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        @Override
+        public DoubleHistogramBuilder setUnit(String unit) {
+            this.unit = unit;
+            return this;
+        }
+
+        @Override
+        public ExtendedDoubleHistogramBuilder setAttributesAdvice(List<AttributeKey<?>> attributes) {
+            this.attributes = attributes;
+            return this;
+        }
+
+        @Override
+        public DoubleHistogramBuilder setExplicitBucketBoundariesAdvice(List<Double> bucketBoundaries) {
+            this.bucketBoundaries = bucketBoundaries;
+            return this;
+        }
+
+        @Override
+        public LongHistogramBuilder ofLongs() {
+            return new LongHistogramBuilderMock(meterId, meterProviderId);
+        }
+
+        @Override
+        public DoubleHistogram build() {
+            return new DoubleHistogramMock(meterId, meterProviderId);
+        }
+    }
+
+    static class DoubleHistogramMock implements DoubleHistogram {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+        final String meterProviderId;
+        final String meterId;
+        final String id;
+
+        public DoubleHistogramMock(String meterId, String meterProviderId) {
+            this.id = "DoubleHistogramMock-" + ID_SOURCE.incrementAndGet();
+            this.meterId = meterId;
+            this.meterProviderId = meterProviderId;
+        }
+
+        @Override
+        public void record(double value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void record(double value, Attributes attributes) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void record(double value, Attributes attributes, Context context) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    static class LongHistogramBuilderMock implements ExtendedLongHistogramBuilder {
+        final String meterId;
+        final String meterProviderId;
+        String description;
+        String unit;
+        List<AttributeKey<?>> attributes;
+        List<Long> bucketBoundaries;
+
+        public LongHistogramBuilderMock(String meterId, String meterProviderId) {
+            this.meterId = meterId;
+            this.meterProviderId = meterProviderId;
+        }
+
+        @Override
+        public ExtendedLongHistogramBuilder setDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        @Override
+        public ExtendedLongHistogramBuilder setUnit(String unit) {
+            this.unit = unit;
+            return this;
+        }
+
+        @Override
+        public ExtendedLongHistogramBuilder setAttributesAdvice(List<AttributeKey<?>> attributes) {
+            this.attributes = attributes;
+            return this;
+        }
+
+        @Override
+        public ExtendedLongHistogramBuilder setExplicitBucketBoundariesAdvice(List<Long> bucketBoundaries) {
+            this.bucketBoundaries = bucketBoundaries;
+            return this;
+        }
+
+        @Override
+        public LongHistogram build() {
+            return new LongHistogramMock(meterId, meterProviderId);
+        }
+    }
+
+    static class LongHistogramMock implements LongHistogram {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+        final String meterProviderId;
+        final String meterId;
+        final String id;
+
+        public LongHistogramMock(String meterId, String meterProviderId) {
+            this.id = "LongHistogramMock-" + ID_SOURCE.incrementAndGet();
+            this.meterId = meterId;
+            this.meterProviderId = meterProviderId;
+        }
+
+        @Override
+        public void record(long value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void record(long value, Attributes attributes) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void record(long value, Attributes attributes, Context context) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/src/test/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableTracerProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableTracerProviderTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.api;
+
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerBuilder;
+import io.opentelemetry.api.trace.TracerProvider;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
+
+public class ReconfigurableTracerProviderTest {
+    @org.junit.Test
+    public void test() {
+        ReconfigurableTracerProvider tracerProvider = new ReconfigurableTracerProvider();
+
+        TracerProviderMock tracerProviderImpl_1 = new TracerProviderMock();
+        tracerProvider.setDelegate(tracerProviderImpl_1);
+
+        ReconfigurableTracerProvider.ReconfigurableTracer authenticationTracer = (ReconfigurableTracerProvider.ReconfigurableTracer) tracerProvider
+            .tracerBuilder("io.jenkins.authentication")
+            .setInstrumentationVersion("1.0.0")
+            .build();
+
+        TracerMock authenticationTracerImpl = (TracerMock) authenticationTracer.delegate;
+        assertEquals("io.jenkins.authentication", authenticationTracerImpl.instrumentationScopeName);
+        assertNull(authenticationTracerImpl.schemaUrl);
+        assertEquals("1.0.0", authenticationTracerImpl.instrumentationVersion);
+        assertEquals(tracerProviderImpl_1.id, authenticationTracerImpl.tracerProviderId);
+
+
+        ReconfigurableTracerProvider.ReconfigurableTracer buildTracer = (ReconfigurableTracerProvider.ReconfigurableTracer) tracerProvider
+            .tracerBuilder("io.jenkins.build")
+            .setSchemaUrl("https://jenkins.io/build")
+            .build();
+        TracerMock buildTracerImpl = (TracerMock) buildTracer.delegate;
+        assertEquals("io.jenkins.build", buildTracerImpl.instrumentationScopeName);
+        assertEquals("https://jenkins.io/build", buildTracerImpl.schemaUrl);
+        assertNull(buildTracerImpl.instrumentationVersion);
+        assertEquals(tracerProviderImpl_1.id, buildTracerImpl.tracerProviderId);
+
+        ReconfigurableTracerProvider.ReconfigurableTracer buildTracerShouldBeTheSameInstance = (ReconfigurableTracerProvider.ReconfigurableTracer) tracerProvider
+            .tracerBuilder("io.jenkins.build")
+            .setSchemaUrl("https://jenkins.io/build")
+            .build();
+
+        assertEquals(buildTracer, buildTracerShouldBeTheSameInstance);
+
+        TracerProviderMock tracerProviderImpl_2 = new TracerProviderMock();
+        assertNotEquals(tracerProviderImpl_1.id, tracerProviderImpl_2.id);
+
+        // CHANGE THE IMPLEMENTATION OF THE EVENT TRACER PROVIDER
+        tracerProvider.setDelegate(tracerProviderImpl_2);
+
+        // VERIFY THE DELEGATE IMPL HAS CHANGED WHILE THE PARAMS REMAINS UNCHANGED
+        TracerMock authenticationTracerImpl_2 = (TracerMock) authenticationTracer.delegate;
+        assertEquals("io.jenkins.authentication", authenticationTracerImpl_2.instrumentationScopeName);
+        assertNull(authenticationTracerImpl_2.schemaUrl);
+        assertEquals("1.0.0", authenticationTracerImpl_2.instrumentationVersion);
+        assertEquals(tracerProviderImpl_2.id, authenticationTracerImpl_2.tracerProviderId);
+
+        TracerMock buildTracerImpl_2 = (TracerMock) buildTracer.delegate;
+
+        assertEquals("io.jenkins.build", buildTracerImpl_2.instrumentationScopeName);
+        assertEquals("https://jenkins.io/build", buildTracerImpl_2.schemaUrl);
+        assertNull(buildTracerImpl_2.instrumentationVersion);
+        assertEquals(tracerProviderImpl_2.id, buildTracerImpl_2.tracerProviderId);
+    }
+
+
+    static class TracerProviderMock implements TracerProvider {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+        final String id;
+
+        public TracerProviderMock() {
+            this.id = "TracerProviderMock-" + ID_SOURCE.incrementAndGet();
+        }
+
+        @Override
+        public TracerBuilder tracerBuilder(String instrumentationScopeName) {
+            return new TracerBuilderMock(instrumentationScopeName, id);
+        }
+
+        @Override
+        public Tracer get(String instrumentationScopeName) {
+            return new TracerMock(instrumentationScopeName, id);
+        }
+
+        @Override
+        public Tracer get(String instrumentationScopeName, String instrumentationScopeVersion) {
+            return new TracerMock(instrumentationScopeName, instrumentationScopeVersion, id);
+        }
+    }
+
+    static class TracerMock implements Tracer {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+
+        final String instrumentationScopeName;
+        final String tracerProviderId;
+        final String id;
+
+        final String schemaUrl;
+        final String instrumentationVersion;
+
+        public TracerMock(String instrumentationScopeName, String tracerProviderId) {
+            this(instrumentationScopeName, tracerProviderId, null, null);
+        }
+        public TracerMock(String instrumentationScopeName, String instrumentationVersion, String tracerProviderId) {
+            this(instrumentationScopeName, tracerProviderId, null, instrumentationVersion);
+        }
+
+        public TracerMock(String instrumentationScopeName, String tracerProviderId, @Nullable String schemaUrl, @Nullable String instrumentationVersion) {
+            this.id = "TracerMock-" + ID_SOURCE.incrementAndGet();
+            this.instrumentationScopeName = instrumentationScopeName;
+            this.tracerProviderId = tracerProviderId;
+            this.schemaUrl = schemaUrl;
+            this.instrumentationVersion = instrumentationVersion;
+        }
+
+        @Override
+        public SpanBuilder spanBuilder(String spanName) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    static class TracerBuilderMock implements TracerBuilder {
+        static AtomicInteger ID_SOURCE = new AtomicInteger(0);
+        final String id;
+        final String instrumentationScopeName;
+        final String tracerProviderId;
+        String schemaUrl;
+        String instrumentationVersion;
+
+
+        public TracerBuilderMock(String instrumentationScopeName, String tracerProviderId) {
+            this.id = "TracerBuilderMock-" + ID_SOURCE.incrementAndGet();
+            this.instrumentationScopeName = instrumentationScopeName;
+            this.tracerProviderId = tracerProviderId;
+        }
+
+        @Override
+        public TracerBuilder setSchemaUrl(String schemaUrl) {
+            this.schemaUrl = schemaUrl;
+            return this;
+        }
+
+        @Override
+        public TracerBuilder setInstrumentationVersion(String instrumentationVersion) {
+            this.instrumentationVersion = instrumentationVersion;
+            return this;
+        }
+
+        @Override
+        public Tracer build() {
+            return new TracerMock(instrumentationScopeName, tracerProviderId, schemaUrl, instrumentationVersion);
+        }
+    }
+}


### PR DESCRIPTION
Add `ReconfigurableOpenTelemetry` to the otel api plugin.

It enables to decouple plugins using OTel like the Junit Result Storage Plugin from the Jenkins OTel Plugin.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
