### PR TITLE
Add resource attributes lost moving ReconfigurableOpenTelemetry to opentelemetry-api-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,18 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
+            <version>2.12.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-runtime-telemetry-java8</artifactId>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/opentelemetry-api-plugin</gitHubRepo>
         <opentelemetry.version>1.40.0</opentelemetry.version>
-        <opentelemetry-instrumentation.version>2.5.0</opentelemetry-instrumentation.version>
-        <opentelemetry-semconv.version>1.26.0-alpha</opentelemetry-semconv.version>
+        <opentelemetry-instrumentation.version>2.6.0</opentelemetry-instrumentation.version>
+        <opentelemetry-semconv.version>1.25.0-alpha</opentelemetry-semconv.version>
 
         <jenkins.version>2.440.3</jenkins.version>
 
@@ -102,12 +102,26 @@
             <artifactId>opentelemetry-exporter-prometheus</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-resources</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>okhttp-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-apache-httpclient-4.3</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>apache-httpcomponents-client-4-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/instrumentation/resource/JenkinsResourceProvider.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/instrumentation/resource/JenkinsResourceProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.api.instrumentation.resource;
+
+import io.jenkins.plugins.opentelemetry.api.semconv.JenkinsAttributes;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.resources.ResourceBuilder;
+import io.opentelemetry.semconv.ServiceAttributes;
+import io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes;
+
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class JenkinsResourceProvider implements ResourceProvider {
+    private final static Logger LOGGER = Logger.getLogger(JenkinsResourceProvider.class.getName());
+
+    @Override
+    public Resource createResource(ConfigProperties config) {
+        ResourceBuilder resourceBuilder = Resource.builder();
+        resourceBuilder.put(ServiceAttributes.SERVICE_NAME, JenkinsAttributes.JENKINS);
+        resourceBuilder.put(ServiceIncubatingAttributes.SERVICE_NAMESPACE, JenkinsAttributes.JENKINS);
+
+        Optional<String> jenkinsVersion = Optional.ofNullable(config.getString(JenkinsAttributes.JENKINS_VERSION.getKey()));
+        jenkinsVersion.ifPresent(version -> resourceBuilder.put(ServiceAttributes.SERVICE_VERSION, version));
+        // Report jenkins.version even if service.version is overriden
+        jenkinsVersion.ifPresent(version -> resourceBuilder.put(JenkinsAttributes.JENKINS_VERSION.getKey(), version));
+
+        Optional<String> jenkinsUrl = Optional.ofNullable(config.getString(JenkinsAttributes.JENKINS_URL.getKey()));
+        jenkinsUrl.ifPresent(version -> resourceBuilder.put(JenkinsAttributes.JENKINS_URL, version));
+
+        Optional<String> serviceInstanceId = Optional.ofNullable(config.getString(ServiceIncubatingAttributes.SERVICE_INSTANCE_ID.getKey()));
+        serviceInstanceId.ifPresent(version -> resourceBuilder.put(ServiceIncubatingAttributes.SERVICE_INSTANCE_ID, version));
+        Resource resource = resourceBuilder.build();
+        LOGGER.log(Level.FINER, () -> "Jenkins resource: " + resource);
+        return resource;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/semconv/JenkinsAttributes.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/semconv/JenkinsAttributes.java
@@ -12,7 +12,7 @@ import jenkins.model.Jenkins;
  * @see io.opentelemetry.api.common.Attributes
  * @see io.opentelemetry.semconv.ServiceAttributes
  */
-public final class JenkinsAttributes {
+public class JenkinsAttributes {
 
     /**
      * @see Jenkins#getRootUrl()

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/semconv/JenkinsAttributes.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/semconv/JenkinsAttributes.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.api.semconv;
+
+import io.opentelemetry.api.common.AttributeKey;
+import jenkins.model.Jenkins;
+
+/**
+ * @see io.opentelemetry.api.common.Attributes
+ * @see io.opentelemetry.semconv.ServiceAttributes
+ */
+public final class JenkinsAttributes {
+
+    /**
+     * @see Jenkins#getRootUrl()
+     */
+    public static final AttributeKey<String> JENKINS_URL = AttributeKey.stringKey("jenkins.url");
+
+    public static final String JENKINS = "jenkins";
+
+    public static final AttributeKey<String> JENKINS_VERSION = AttributeKey.stringKey("jenkins.version");
+
+}

--- a/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
+++ b/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
@@ -1,0 +1,1 @@
+io.jenkins.plugins.opentelemetry.api.instrumentation.resource.JenkinsResourceProvider

--- a/src/test/java/io/jenkins/plugins/opentelemetry/ApacheHttpClientInstrumentationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/ApacheHttpClientInstrumentationTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 public class ApacheHttpClientInstrumentationTest {
 
     @Test
-    public void test() {
+    public void test_instantiate_instrumented_http_client() {
         ReconfigurableOpenTelemetry openTelemetry = new ReconfigurableOpenTelemetry();
         HttpClientBuilder httpClientBuilder = ApacheHttpClientTelemetry.create(openTelemetry).newHttpClientBuilder();
         CloseableHttpClient httpClient = httpClientBuilder.build();

--- a/src/test/java/io/jenkins/plugins/opentelemetry/ApacheHttpClientInstrumentationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/ApacheHttpClientInstrumentationTest.java
@@ -1,0 +1,18 @@
+package io.jenkins.plugins.opentelemetry;
+
+import io.jenkins.plugins.opentelemetry.api.ReconfigurableOpenTelemetry;
+import io.opentelemetry.instrumentation.apachehttpclient.v4_3.ApacheHttpClientTelemetry;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.Test;
+
+public class ApacheHttpClientInstrumentationTest {
+
+    @Test
+    public void test() {
+        ReconfigurableOpenTelemetry openTelemetry = new ReconfigurableOpenTelemetry();
+        HttpClientBuilder httpClientBuilder = ApacheHttpClientTelemetry.create(openTelemetry).newHttpClientBuilder();
+        CloseableHttpClient httpClient = httpClientBuilder.build();
+        System.out.println(httpClient);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JdbcInstrumentationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JdbcInstrumentationTest.java
@@ -1,0 +1,19 @@
+package io.jenkins.plugins.opentelemetry;
+
+import io.jenkins.plugins.opentelemetry.api.ReconfigurableOpenTelemetry;
+import io.opentelemetry.instrumentation.jdbc.datasource.JdbcTelemetry;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.junit.Test;
+
+import javax.sql.DataSource;
+
+public class JdbcInstrumentationTest {
+
+    @Test
+    public void test_instantiate_instrumented_data_source() {
+        try (ReconfigurableOpenTelemetry openTelemetry = new ReconfigurableOpenTelemetry()) {
+            DataSource dataSource = JdbcTelemetry.create(openTelemetry).wrap(new BasicDataSource());
+            System.out.println(dataSource);
+        }
+    }
+}


### PR DESCRIPTION
Add resource attributes lost moving ReconfigurableOpenTelemetry to opentelemetry-api-plugin.

Default `service.name`, `service.namespace`, `service.version`, `service.instance.id`, and `jenkins.url` where no longer populated if default values set by the GUI were mising (eg config as code use cases).

Fix for:
* https://github.com/jenkinsci/opentelemetry-plugin/issues/905
* https://github.com/jenkinsci/opentelemetry-plugin/issues/906

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
