### PR TITLE
Better thread safety + implement `ExtendedTracer` and ``ExtendedLogger`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <gitHubRepo>jenkinsci/opentelemetry-api-plugin</gitHubRepo>
         <opentelemetry.version>1.40.0</opentelemetry.version>
         <opentelemetry-instrumentation.version>2.5.0</opentelemetry-instrumentation.version>
-        <opentelemetry-semconv.version>1.26.0-alpha</opentelemetry-semconv.version>
+        <opentelemetry-semconv.version>1.25.0-alpha</opentelemetry-semconv.version>
 
         <jenkins.version>2.440.3</jenkins.version>
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableOpenTelemetry.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableOpenTelemetry.java
@@ -88,7 +88,7 @@ public class ReconfigurableOpenTelemetry implements ExtendedOpenTelemetry, OpenT
 
     @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.SYSTEM_CONFIG_LOADED)
     public void init() {
-        logger.log(Level.INFO, "OpenTelemetry initialized as NoOp");
+        logger.log(Level.INFO, "OpenTelemetry configured as NoOp");
     }
 
     public void configure(@NonNull Map<String, String> openTelemetryProperties, Resource openTelemetryResource) {
@@ -98,7 +98,7 @@ public class ReconfigurableOpenTelemetry implements ExtendedOpenTelemetry, OpenT
                 openTelemetryProperties.containsKey("otel.metrics.exporter") ||
                 openTelemetryProperties.containsKey("otel.logs.exporter")) {
 
-            logger.log(Level.FINE, "initializeOtlp");
+            logger.log(Level.FINE, "configure...");
 
             // OPENTELEMETRY SDK
             OpenTelemetrySdk openTelemetrySdk = AutoConfiguredOpenTelemetrySdk
@@ -126,7 +126,7 @@ public class ReconfigurableOpenTelemetry implements ExtendedOpenTelemetry, OpenT
 
             setOpenTelemetryImpl(openTelemetrySdk);
 
-            logger.log(Level.INFO, () -> "OpenTelemetry initialized: " + ConfigPropertiesUtils.prettyPrintOtelSdkConfig(this.config, this.resource));
+            logger.log(Level.INFO, () -> "OpenTelemetry SDK configured: " + ConfigPropertiesUtils.prettyPrintOtelSdkConfig(this.config, this.resource));
 
         } else { // NO-OP
 
@@ -134,7 +134,7 @@ public class ReconfigurableOpenTelemetry implements ExtendedOpenTelemetry, OpenT
             this.config = ConfigPropertiesUtils.emptyConfig();
             setOpenTelemetryImpl(OpenTelemetry.noop());
 
-            logger.log(Level.INFO, "OpenTelemetry initialized as NoOp");
+            logger.log(Level.INFO, "OpenTelemetry configured as NoOp");
         }
 
         postOpenTelemetrySdkConfiguration();


### PR DESCRIPTION
* Improve thread safety of `ReconfigurableOpenTelemetry`
* Implement `ExtendedTracer` and `ExtendedLogger` rather than just `Tracer` and `Logger`


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
