### PR TITLE
Support using `ReconfigurableOpenTelemetry` instance through `@Inject`

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/ExtendedOpenTelemetry.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/ExtendedOpenTelemetry.java
@@ -9,20 +9,48 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
 
 import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
 
+/**
+ * Extension of {@link OpenTelemetry} that provides additional functionality:
+ * <ul>
+ *     <li>Accessor to the {@link EventLoggerProvider} without requiring using a separate {@link io.opentelemetry.api.incubator.events.GlobalEventLoggerProvider}</li>
+ *     <li>Read access top the {@link ConfigProperties} and {@link Resource}</li>
+ *     <li>Ability to be reconfigured through {@link #configure(Map, Resource, boolean)}</li>
+ *     <li>Ability to be used as a Jenkins {@link hudson.Extension}</li>
+ * </ul>
+ */
 public interface ExtendedOpenTelemetry extends ExtensionPoint, OpenTelemetry {
     EventLoggerProvider getEventLoggerProvider();
+
     EventLoggerBuilder eventLoggerBuilder(String instrumentationScopeName);
+
+    /**
+     * {@link ConfigProperties} used to instantiate this OpenTelemetry instance using the {@link io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk}.
+     */
     ConfigProperties getConfig();
+
+    /**
+     * {@link Resource} used by this OpenTelemetry instance for the resource attributes of the produced telemetry
+     */
     Resource getResource();
 
     /**
-     * 
      * @deprecated use {@link #configure(Map, Resource, boolean)}
      */
     @Deprecated
     void configure(@NonNull Map<String, String> openTelemetryProperties, Resource openTelemetryResource);
-    default void configure(@NonNull Map<String, String> openTelemetryProperties, Resource openTelemetryResource, boolean disableShutdownHook){}
+
+    /**
+     * Reconfigures the {@link OpenTelemetry} instance. If no exporter is explicitly defined, this OpenTelemetry instance is NoOp.
+     *
+     * @param openTelemetryProperties properties used as {@link ConfigProperties} through {@link io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder#addPropertiesSupplier(Supplier)}
+     * @param openTelemetryResource   resource attributes passed through {@link io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder#addResourceCustomizer(BiFunction)}
+     * @param disableShutdownHook     enable / disable a shutdown hook
+     */
+    default void configure(@NonNull Map<String, String> openTelemetryProperties, Resource openTelemetryResource, boolean disableShutdownHook) {
+    }
 
     @Deprecated
     OpenTelemetry getImplementation();

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/OpenTelemetryApiGuiceModule.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/OpenTelemetryApiGuiceModule.java
@@ -1,0 +1,29 @@
+package io.jenkins.plugins.opentelemetry.api;
+
+import com.google.inject.AbstractModule;
+import hudson.Extension;
+import io.opentelemetry.api.OpenTelemetry;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Support using @{@link javax.inject.Inject} to inject the OpenTelemetry instance in Jenkins @{@link Extension}.
+ */
+@Extension
+public class OpenTelemetryApiGuiceModule extends AbstractModule  {
+    static final Logger logger = Logger.getLogger(OpenTelemetryApiGuiceModule.class.getName());
+
+    public OpenTelemetryApiGuiceModule() {
+        logger.log(Level.FINE, "Creating OpenTelemetryApiGuiceModule");
+    }
+
+    @Override
+    public void configure() {
+        logger.log(Level.FINE, "Configuring OpenTelemetryApiGuiceModule");
+        ReconfigurableOpenTelemetry reconfigurableOpenTelemetry = ReconfigurableOpenTelemetry.get();
+        bind(OpenTelemetry.class).toInstance(reconfigurableOpenTelemetry);
+        bind(ExtendedOpenTelemetry.class).toInstance(reconfigurableOpenTelemetry);
+        bind(ReconfigurableOpenTelemetry.class).toInstance(reconfigurableOpenTelemetry);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/opentelemetry/ApacheHttpClientInstrumentationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/ApacheHttpClientInstrumentationTest.java
@@ -10,9 +10,10 @@ public class ApacheHttpClientInstrumentationTest {
 
     @Test
     public void test_instantiate_instrumented_http_client() {
-        ReconfigurableOpenTelemetry openTelemetry = new ReconfigurableOpenTelemetry();
-        HttpClientBuilder httpClientBuilder = ApacheHttpClientTelemetry.create(openTelemetry).newHttpClientBuilder();
-        CloseableHttpClient httpClient = httpClientBuilder.build();
-        System.out.println(httpClient);
+        try (ReconfigurableOpenTelemetry openTelemetry = new ReconfigurableOpenTelemetry()) {
+            HttpClientBuilder httpClientBuilder = ApacheHttpClientTelemetry.create(openTelemetry).newHttpClientBuilder();
+            CloseableHttpClient httpClient = httpClientBuilder.build();
+            System.out.println(httpClient);
+        }
     }
 }


### PR DESCRIPTION
Support using `ReconfigurableOpenTelemetry` instance through `@Inject` in addition to the traditional Jenkins `hudson.ExtensionList#lookup()`.

Implemented introducing a `com.google.inject.AbstractModule` annotated with `@Extension`


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
