### PR TITLE
chore: enable spotless

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# spotless formatting
+66006f513b1f0cb282f41b88870229b7a2bd382e

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/opentelemetry-api-plugin</gitHubRepo>
     <revision>${opentelemetry.version}</revision>
+    <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This pull request includes two changes related to code formatting and build configuration. The changes add support for Spotless formatting and ensure that the Spotless check is not skipped during the build process.

### Formatting and build configuration updates:

* [`.git-blame-ignore-revs`](diffhunk://#diff-f247fbfbe928b907db42554d0b3006b28dd11c25a59be031abda73b11a2c934aR1-R2): Added a commit hash to ignore Spotless formatting changes in blame annotations.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R52): Added the `<spotless.check.skip>` property and set it to `false` to ensure that Spotless checks are enforced during the build.