### PR TITLE
chore: bump Jenkins Core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
 
     <auto-value.version>1.11.0</auto-value.version>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.baseline>2.504</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
 
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/opentelemetry-api-plugin</gitHubRepo>


### PR DESCRIPTION
This pull request updates the Jenkins baseline and version in the `pom.xml` file to align with newer Jenkins releases.

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L46-R47): Updated the `jenkins.baseline` from `2.479` to `2.504` and the `jenkins.version` from `${jenkins.baseline}.3` to `${jenkins.baseline}.1`.