### PR TITLE
Enable strict bundled artifact checks and remove jsr305 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.19</version>
+    <version>5.24</version>
     <relativePath />
   </parent>
 
@@ -50,6 +50,8 @@
     <gitHubRepo>jenkinsci/opentelemetry-api-plugin</gitHubRepo>
     <revision>${opentelemetry.version}</revision>
     <spotless.check.skip>false</spotless.check.skip>
+    <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
+    <hpi.bundledArtifacts>opentelemetry-api,opentelemetry-api-incubator,opentelemetry-context,opentelemetry-exporter-common,opentelemetry-exporter-logging,opentelemetry-exporter-otlp,opentelemetry-exporter-otlp-common,opentelemetry-exporter-prometheus,opentelemetry-exporter-sender-okhttp,opentelemetry-instrumentation-api,opentelemetry-instrumentation-api-incubator,opentelemetry-resources,opentelemetry-sdk,opentelemetry-sdk-common,opentelemetry-sdk-extension-autoconfigure,opentelemetry-sdk-extension-autoconfigure-spi,opentelemetry-sdk-logs,opentelemetry-sdk-metrics,opentelemetry-sdk-trace,opentelemetry-semconv,opentelemetry-semconv-incubating,prometheus-metrics-config,prometheus-metrics-exporter-common,prometheus-metrics-exporter-httpserver,prometheus-metrics-exposition-formats,prometheus-metrics-exposition-textformats,prometheus-metrics-model</hpi.bundledArtifacts>
   </properties>
 
   <dependencyManagement>
@@ -92,11 +94,6 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-    </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>okhttp-api</artifactId>

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/InstrumentationScope.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/InstrumentationScope.java
@@ -5,16 +5,16 @@
 
 package io.jenkins.plugins.opentelemetry.api;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Objects;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * <a href="https://opentelemetry.io/docs/concepts/instrumentation-scope/">OpenTelemetry instrumentation scope</a>,
  * data structured used by the {@link ReconfigurableOpenTelemetry} implementation
  */
 class InstrumentationScope {
-    @Nonnull
+    @NonNull
     final String instrumentationScopeName;
 
     @Nullable
@@ -30,7 +30,7 @@ class InstrumentationScope {
         this.instrumentationScopeVersion = instrumentationScopeVersion;
     }
 
-    public InstrumentationScope(@Nonnull String instrumentationScopeName) {
+    public InstrumentationScope(@NonNull String instrumentationScopeName) {
         this.instrumentationScopeName = instrumentationScopeName;
         this.schemaUrl = null;
         this.instrumentationScopeVersion = null;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableMeterProvider.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableMeterProvider.java
@@ -6,6 +6,7 @@
 package io.jenkins.plugins.opentelemetry.api;
 
 import com.google.common.annotations.VisibleForTesting;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.incubator.metrics.ExtendedDoubleCounter;
@@ -55,9 +56,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
-import javax.annotation.concurrent.ThreadSafe;
+import net.jcip.annotations.GuardedBy;
+import net.jcip.annotations.ThreadSafe;
 
 /**
  * <p>

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableOpenTelemetry.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableOpenTelemetry.java
@@ -7,6 +7,7 @@ package io.jenkins.plugins.opentelemetry.api;
 
 import com.google.common.base.Function;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.OverrideMustInvoke;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
@@ -38,7 +39,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.OverridingMethodsMustInvokeSuper;
 import javax.annotation.PreDestroy;
 
 /**
@@ -317,7 +317,7 @@ public class ReconfigurableOpenTelemetry implements ExtendedOpenTelemetry, OpenT
         return logRecordExporter;
     }
 
-    @OverridingMethodsMustInvokeSuper
+    @OverrideMustInvoke
     protected void postOpenTelemetrySdkConfiguration() {
         ExtensionList.lookup(OpenTelemetryLifecycleListener.class).stream()
                 .sorted()

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableTracerProvider.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableTracerProvider.java
@@ -6,6 +6,7 @@
 package io.jenkins.plugins.opentelemetry.api;
 
 import com.google.common.annotations.VisibleForTesting;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.opentelemetry.api.incubator.trace.ExtendedSpanBuilder;
 import io.opentelemetry.api.incubator.trace.ExtendedTracer;
 import io.opentelemetry.api.trace.Tracer;
@@ -17,7 +18,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import javax.annotation.Nonnull;
 
 /**
  * <p>
@@ -184,7 +184,7 @@ class ReconfigurableTracerProvider implements TracerProvider {
         }
 
         @Override
-        public ExtendedSpanBuilder spanBuilder(@Nonnull String spanName) {
+        public ExtendedSpanBuilder spanBuilder(@NonNull String spanName) {
             lock.readLock().lock();
             try {
                 return delegate.spanBuilder(spanName);

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/logs/AutoValue_TestLogRecordData.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/logs/AutoValue_TestLogRecordData.java
@@ -1,12 +1,12 @@
 package io.jenkins.plugins.opentelemetry.api.logs;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.logs.data.Body;
 import io.opentelemetry.sdk.resources.Resource;
-import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 /**

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/logs/TestLogRecordData.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/logs/TestLogRecordData.java
@@ -15,7 +15,7 @@ import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.resources.Resource;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.concurrent.Immutable;
+import net.jcip.annotations.Immutable;
 
 /**
  * <p>

--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/package-info.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/package-info.java
@@ -1,9 +1,0 @@
-/*
- * Copyright The Original Author or Authors
- * SPDX-License-Identifier: Apache-2.0
- */
-
-@ParametersAreNonnullByDefault
-package io.jenkins.plugins.opentelemetry.api;
-
-import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/test/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableExtendedLoggerProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableExtendedLoggerProviderTest.java
@@ -7,6 +7,7 @@ package io.jenkins.plugins.opentelemetry.api;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder;
 import io.opentelemetry.api.incubator.logs.ExtendedLogger;
 import io.opentelemetry.api.logs.LogRecordBuilder;
@@ -14,7 +15,6 @@ import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.api.logs.LoggerBuilder;
 import io.opentelemetry.api.logs.LoggerProvider;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 
 class ReconfigurableExtendedLoggerProviderTest {

--- a/src/test/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableExtendedTracerProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableExtendedTracerProviderTest.java
@@ -7,6 +7,7 @@ package io.jenkins.plugins.opentelemetry.api;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import io.opentelemetry.api.incubator.trace.ExtendedSpanBuilder;
 import io.opentelemetry.api.incubator.trace.ExtendedTracer;
 import io.opentelemetry.api.trace.SpanBuilder;
@@ -14,7 +15,6 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerBuilder;
 import io.opentelemetry.api.trace.TracerProvider;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 
 class ReconfigurableExtendedTracerProviderTest {


### PR DESCRIPTION
This PR enables strict checking of bundled artifacts. The motivation is described in https://github.com/jenkinsci/maven-hpi-plugin/issues/557. This should help prevent accidental library bundling when adding and updating dependencies.

When enabling these checks, I realized that this plugin was bundling and using `jsr305`, which we try to avoid in the Jenkins ecosystem. See for example https://github.com/jenkinsci/jenkins/pull/4604 and the many linked PRs. I removed the dependency and replaced the imports with either SpotBugs or `jcip-annotations` (which comes from Jenkins core), with one exception where I am not aware of a supported replacement (package-level `ParametersAreNonnullByDefault `).

### Testing done

`mvn verify` passes with this PR.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
