### PR TITLE
fix: ban OpenTelemetry alpha updates from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,13 @@ updates:
       otel-dependencies:
         patterns:
             - "io.opentelemetry*"
+    ignore:
+        - dependency-name: "io.opentelemetry*"
+          versions:
+            - "*-alpha*"
+            - "*-beta*"
+            - "*-RC*"
+            - "*-rc*"
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
This pull request makes a small configuration change to the `.github/dependabot.yml` file. The update ensures that Dependabot ignores pre-release versions (alpha, beta, RC) of dependencies matching `io.opentelemetry*` during updates.