### PR TITLE
chore: enable spotless

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/opentelemetry-api-plugin</gitHubRepo>
         <revision>${opentelemetry.version}</revision>
+        <spotless.check.skip>false</spotless.check.skip>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
This pull request makes a configuration update to the `pom.xml` file, ensuring that Spotless code formatting checks are not skipped during the build process.

- Build configuration:
  * Set the `spotless.check.skip` property to `false` in `pom.xml`, which enforces Spotless formatting checks as part of the build.