### PR TITLE
chore: Bump Jenkins Core to 2.516.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
 
     <auto-value.version>1.11.1</auto-value.version>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.504</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.baseline>2.516</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
 
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/opentelemetry-api-plugin</gitHubRepo>


### PR DESCRIPTION
This pull request updates the Jenkins baseline and version in the `pom.xml` file to ensure compatibility with newer Jenkins releases.

Dependency version update:

* Increased the `jenkins.baseline` from `2.504` to `2.516` and updated `jenkins.version` from `${jenkins.baseline}.1` to `${jenkins.baseline}.3` to align with the latest supported Jenkins versions.