### PR TITLE
fix: remove jvm.cpu.recent_utilization metric assert

### DIFF
--- a/src/test/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableMeterProviderITTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableMeterProviderITTest.java
@@ -96,7 +96,6 @@ class ReconfigurableMeterProviderITTest {
                 Cpu.registerObservers(reconfigurableOpenTelemetry);
                 assertMetricExist("jvm.cpu.count", metricReader);
                 assertMetricExist("jvm.cpu.time", metricReader);
-                assertMetricExist("jvm.cpu.recent_utilization", metricReader);
             }
         }
     }
@@ -179,7 +178,6 @@ class ReconfigurableMeterProviderITTest {
 
                 assertMetricExist("jvm.cpu.count", metricReader);
                 assertMetricExist("jvm.cpu.time", metricReader);
-                assertMetricExist("jvm.cpu.recent_utilization", metricReader);
             }
         }
     }


### PR DESCRIPTION
This pull request makes a minor update to the test suite for the OpenTelemetry Jenkins plugin. Specifically, it removes the assertion that checks for the existence of the `jvm.cpu.recent_utilization` metric in two integration tests.

Testing adjustments:

* Removed the assertion for the `jvm.cpu.recent_utilization` metric in the `testReconfigurableOpenTelemetrySdk` and `testReconfigurableOpenTelemetrySdkAfterNopInitialization` test methods in `ReconfigurableMeterProviderITTest.java`. [[1]](diffhunk://#diff-305265bd1eaab6a95465f6bc3931616f7945fb444f135a12a99874445afdf0d4L99) [[2]](diffhunk://#diff-305265bd1eaab6a95465f6bc3931616f7945fb444f135a12a99874445afdf0d4L182)

When the assert is evaluated, the metric may not be present, making the test flaky. Assert that metrics are not important for the test, so we remove them and the flakiness.