### PR TITLE
Expose the metric reader for use in tests

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableOpenTelemetry.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/api/ReconfigurableOpenTelemetry.java
@@ -28,6 +28,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import io.opentelemetry.sdk.metrics.export.MetricReader;
 import io.opentelemetry.sdk.resources.Resource;
 import java.io.Closeable;
 import java.util.Collection;
@@ -66,6 +67,7 @@ public class ReconfigurableOpenTelemetry implements ExtendedOpenTelemetry, OpenT
     ConfigProperties config = ConfigPropertiesUtils.emptyConfig();
     OpenTelemetry openTelemetryImpl = OpenTelemetry.noop();
     LogRecordExporter logRecordExporter = NoopLogRecordExporter.getInstance();
+    MetricReader metricReader;
     Thread shutdownHook;
     final ReconfigurableMeterProvider meterProviderImpl = new ReconfigurableMeterProvider();
     final ReconfigurableTracerProvider traceProviderImpl = new ReconfigurableTracerProvider();
@@ -187,6 +189,11 @@ public class ReconfigurableOpenTelemetry implements ExtendedOpenTelemetry, OpenT
                         // keep a reference to the computed LogRecordExporter for future use in the plugin
                         this.logRecordExporter = logRecordExporter;
                         return logRecordExporter;
+                    })
+                    .addMetricReaderCustomizer((metricReader, configProperties) -> {
+                        // keep a reference to the computed MetricReader for future use in the plugin
+                        this.metricReader = metricReader;
+                        return metricReader;
                     })
                     .disableShutdownHook()
                     .build()
@@ -324,6 +331,13 @@ public class ReconfigurableOpenTelemetry implements ExtendedOpenTelemetry, OpenT
      */
     public LogRecordExporter getLogRecordExporter() {
         return logRecordExporter;
+    }
+
+    /**
+     * For testing and troubleshooting purpose
+     */
+    public MetricReader getMetricReader() {
+        return metricReader;
     }
 
     @OverridingMethodsMustInvokeSuper


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Expose the metric reader (by default a PeriodicMetricReader) for use in tests to be able to call `forceFlush()` on it, triggering a scrape of metrics.

### Testing done

- [x] Tested with [opentelemetry-plugin](https://github.com/kamphaus/opentelemetry-plugin/tree/add-otel-cicd-metrics) (PR: https://github.com/jenkinsci/opentelemetry-plugin/pull/1251)
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
